### PR TITLE
Feat: 콘테스트 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.174'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dangdangsalon/config/S3Config.java
+++ b/src/main/java/com/dangdangsalon/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.dangdangsalon.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/dangdangsalon/config/SecurityConfig.java
+++ b/src/main/java/com/dangdangsalon/config/SecurityConfig.java
@@ -36,11 +36,12 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable) // Form 로그인 방식 disable
                 .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 방식 disable
                 .oauth2Login((oauth2) -> oauth2.userInfoEndpoint(
-                        (userInfoEndpointConfig) -> userInfoEndpointConfig.userService(customOAuth2UserService))
+                                (userInfoEndpointConfig) -> userInfoEndpointConfig.userService(customOAuth2UserService))
                         .successHandler(customSuccessHandler))
                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정 적용
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/oauth2/authorization/**","/api/test", "/actuator/**")
+                        .requestMatchers("/oauth2/authorization/**", "/api/test", "/actuator/**",
+                                "/api/contests/winner/**")
                         .permitAll()
                         .requestMatchers("/api/auth/join").hasRole("PENDING")
                         .anyRequest().hasAnyRole("USER", "SALON", "ADMIN") // 나머지 경로는 인증 필요
@@ -57,7 +58,8 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("https://dangdangsalon.netlify.app", "http://localhost:5173")); // 허용할 Origin
+        configuration.setAllowedOrigins(
+                List.of("https://dangdangsalon.netlify.app", "http://localhost:5173")); // 허용할 Origin
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE")); // 허용할 HTTP 메서드
         configuration.setAllowedHeaders(List.of("*")); // 허용할 헤더
         configuration.setExposedHeaders(List.of("*")); // 노출할 헤더

--- a/src/main/java/com/dangdangsalon/config/SecurityConfig.java
+++ b/src/main/java/com/dangdangsalon/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정 적용
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/oauth2/authorization/**", "/api/test", "/actuator/**",
-                                "/api/contests/winner/**")
+                                "/api/contests/winner/**", "/api/images/**")
                         .permitAll()
                         .requestMatchers("/api/auth/join").hasRole("PENDING")
                         .anyRequest().hasAnyRole("USER", "SALON", "ADMIN") // 나머지 경로는 인증 필요

--- a/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
@@ -3,7 +3,9 @@ package com.dangdangsalon.domain.contest.controller;
 import com.dangdangsalon.domain.auth.dto.CustomOAuth2User;
 import com.dangdangsalon.domain.contest.dto.ContestDetailDto;
 import com.dangdangsalon.domain.contest.dto.ContestInfoDto;
+import com.dangdangsalon.domain.contest.dto.LastContestWinnerDto;
 import com.dangdangsalon.domain.contest.dto.PostInfoDto;
+import com.dangdangsalon.domain.contest.dto.WinnerRankDto;
 import com.dangdangsalon.domain.contest.service.ContestPostService;
 import com.dangdangsalon.domain.contest.service.ContestService;
 import com.dangdangsalon.util.ApiUtil;
@@ -57,5 +59,19 @@ public class ContestController {
         boolean alreadyParticipated = contestService.checkUserParticipated(contestId, userId);
 
         return ApiUtil.success(Map.of("already_participated", alreadyParticipated));
+    }
+
+    @GetMapping("/winner/last")
+    public ApiSuccess<?> getLastContestWinner() {
+        LastContestWinnerDto winner = contestService.getLastContestWinner();
+
+        return ApiUtil.success(winner);
+    }
+
+    @GetMapping("/winner/rank")
+    public ApiSuccess<?> getWinnerAndRankPost() {
+        WinnerRankDto rankDto = contestService.getWinnerAndRankPost();
+
+        return ApiUtil.success(rankDto);
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -61,5 +62,13 @@ public class ContestController {
         contestPostService.joinContest(contestId, requestDto, userId);
 
         return ApiUtil.success("콘테스트 참여에 성공했습니다!");
+    }
+
+    @DeleteMapping("/{postId}")
+    public ApiSuccess<?> deletePost(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User user) {
+        Long userId = user.getUserId();
+        contestPostService.deletePost(postId, userId);
+
+        return ApiUtil.success("포스트 삭제가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
@@ -1,0 +1,24 @@
+package com.dangdangsalon.domain.contest.controller;
+
+import com.dangdangsalon.domain.contest.dto.ContestInfoDto;
+import com.dangdangsalon.domain.contest.service.ContestService;
+import com.dangdangsalon.util.ApiUtil;
+import com.dangdangsalon.util.ApiUtil.ApiSuccess;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/contests")
+public class ContestController {
+
+    private final ContestService contestService;
+
+    @GetMapping
+    public ApiSuccess<?> getContest() {
+        ContestInfoDto contest = contestService.getLatestContest();
+        return ApiUtil.success(contest);
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
@@ -1,5 +1,6 @@
 package com.dangdangsalon.domain.contest.controller;
 
+import com.dangdangsalon.domain.auth.dto.CustomOAuth2User;
 import com.dangdangsalon.domain.contest.dto.ContestDetailDto;
 import com.dangdangsalon.domain.contest.dto.ContestInfoDto;
 import com.dangdangsalon.domain.contest.dto.PostInfoDto;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,8 +38,11 @@ public class ContestController {
     }
 
     @GetMapping("/{contestId}/posts")
-    public ApiSuccess<?> getContestPosts(@PathVariable Long contestId, @PageableDefault(size = 3) Pageable pageable) {
-        Page<PostInfoDto> contestPosts = contestService.getContestPosts(contestId, pageable);
+    public ApiSuccess<?> getContestPosts(@AuthenticationPrincipal CustomOAuth2User user, @PathVariable Long contestId,
+                                         @PageableDefault(size = 3) Pageable pageable) {
+        Long userId = user.getUserId();
+
+        Page<PostInfoDto> contestPosts = contestService.getContestPosts(contestId, userId, pageable);
 
         return ApiUtil.success(contestPosts);
     }

--- a/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
@@ -1,11 +1,17 @@
 package com.dangdangsalon.domain.contest.controller;
 
+import com.dangdangsalon.domain.contest.dto.ContestDetailDto;
 import com.dangdangsalon.domain.contest.dto.ContestInfoDto;
+import com.dangdangsalon.domain.contest.dto.PostInfoDto;
 import com.dangdangsalon.domain.contest.service.ContestService;
 import com.dangdangsalon.util.ApiUtil;
 import com.dangdangsalon.util.ApiUtil.ApiSuccess;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +26,19 @@ public class ContestController {
     public ApiSuccess<?> getContest() {
         ContestInfoDto contest = contestService.getLatestContest();
         return ApiUtil.success(contest);
+    }
+
+    @GetMapping("/{contestId}")
+    public ApiSuccess<?> getContestDetails(@PathVariable Long contestId) {
+        ContestDetailDto details = contestService.getContestDetails(contestId);
+
+        return ApiUtil.success(details);
+    }
+
+    @GetMapping("/{contestId}/posts")
+    public ApiSuccess<?> getContestPosts(@PathVariable Long contestId, @PageableDefault(size = 3) Pageable pageable) {
+        Page<PostInfoDto> contestPosts = contestService.getContestPosts(contestId, pageable);
+
+        return ApiUtil.success(contestPosts);
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
@@ -9,6 +9,7 @@ import com.dangdangsalon.domain.contest.service.ContestPostService;
 import com.dangdangsalon.domain.contest.service.ContestService;
 import com.dangdangsalon.util.ApiUtil;
 import com.dangdangsalon.util.ApiUtil.ApiSuccess;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -70,5 +71,14 @@ public class ContestController {
         contestPostService.deletePost(postId, userId);
 
         return ApiUtil.success("포스트 삭제가 완료되었습니다.");
+    }
+
+    @GetMapping("/{contestId}/check")
+    public ApiSuccess<?> checkAlreadyJoin(@PathVariable Long contestId,
+                                          @AuthenticationPrincipal CustomOAuth2User user) {
+        Long userId = user.getUserId();
+        boolean alreadyParticipated = contestService.checkUserParticipated(contestId, userId);
+
+        return ApiUtil.success(Map.of("already_participated", alreadyParticipated));
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
@@ -3,7 +3,6 @@ package com.dangdangsalon.domain.contest.controller;
 import com.dangdangsalon.domain.auth.dto.CustomOAuth2User;
 import com.dangdangsalon.domain.contest.dto.ContestDetailDto;
 import com.dangdangsalon.domain.contest.dto.ContestInfoDto;
-import com.dangdangsalon.domain.contest.dto.ContestJoinRequestDto;
 import com.dangdangsalon.domain.contest.dto.PostInfoDto;
 import com.dangdangsalon.domain.contest.service.ContestPostService;
 import com.dangdangsalon.domain.contest.service.ContestService;
@@ -15,11 +14,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -52,25 +48,6 @@ public class ContestController {
         Page<PostInfoDto> contestPosts = contestPostService.getContestPosts(contestId, userId, pageable);
 
         return ApiUtil.success(contestPosts);
-    }
-
-    @PostMapping("/{contestId}/join")
-    public ApiSuccess<?> joinContest(@PathVariable Long contestId,
-                                     @RequestBody ContestJoinRequestDto requestDto,
-                                     @AuthenticationPrincipal CustomOAuth2User user) {
-
-        Long userId = user.getUserId();
-        contestPostService.joinContest(contestId, requestDto, userId);
-
-        return ApiUtil.success("콘테스트 참여에 성공했습니다!");
-    }
-
-    @DeleteMapping("/{postId}")
-    public ApiSuccess<?> deletePost(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User user) {
-        Long userId = user.getUserId();
-        contestPostService.deletePost(postId, userId);
-
-        return ApiUtil.success("포스트 삭제가 완료되었습니다.");
     }
 
     @GetMapping("/{contestId}/check")

--- a/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/controller/ContestController.java
@@ -3,7 +3,9 @@ package com.dangdangsalon.domain.contest.controller;
 import com.dangdangsalon.domain.auth.dto.CustomOAuth2User;
 import com.dangdangsalon.domain.contest.dto.ContestDetailDto;
 import com.dangdangsalon.domain.contest.dto.ContestInfoDto;
+import com.dangdangsalon.domain.contest.dto.ContestJoinRequestDto;
 import com.dangdangsalon.domain.contest.dto.PostInfoDto;
+import com.dangdangsalon.domain.contest.service.ContestPostService;
 import com.dangdangsalon.domain.contest.service.ContestService;
 import com.dangdangsalon.util.ApiUtil;
 import com.dangdangsalon.util.ApiUtil.ApiSuccess;
@@ -14,6 +16,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ContestController {
 
     private final ContestService contestService;
+    private final ContestPostService contestPostService;
 
     @GetMapping
     public ApiSuccess<?> getContest() {
@@ -42,8 +47,19 @@ public class ContestController {
                                          @PageableDefault(size = 3) Pageable pageable) {
         Long userId = user.getUserId();
 
-        Page<PostInfoDto> contestPosts = contestService.getContestPosts(contestId, userId, pageable);
+        Page<PostInfoDto> contestPosts = contestPostService.getContestPosts(contestId, userId, pageable);
 
         return ApiUtil.success(contestPosts);
+    }
+
+    @PostMapping("/{contestId}/join")
+    public ApiSuccess<?> joinContest(@PathVariable Long contestId,
+                                     @RequestBody ContestJoinRequestDto requestDto,
+                                     @AuthenticationPrincipal CustomOAuth2User user) {
+
+        Long userId = user.getUserId();
+        contestPostService.joinContest(contestId, requestDto, userId);
+
+        return ApiUtil.success("콘테스트 참여에 성공했습니다!");
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/controller/ContestPostController.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/controller/ContestPostController.java
@@ -1,0 +1,60 @@
+package com.dangdangsalon.domain.contest.controller;
+
+import com.dangdangsalon.domain.auth.dto.CustomOAuth2User;
+import com.dangdangsalon.domain.contest.dto.ContestJoinRequestDto;
+import com.dangdangsalon.domain.contest.service.ContestPostLikeService;
+import com.dangdangsalon.domain.contest.service.ContestPostService;
+import com.dangdangsalon.util.ApiUtil;
+import com.dangdangsalon.util.ApiUtil.ApiSuccess;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts")
+public class ContestPostController {
+
+    private final ContestPostService contestPostService;
+    private final ContestPostLikeService contestPostLikeService;
+
+    @PostMapping
+    public ApiSuccess<?> joinContest(
+            @RequestBody ContestJoinRequestDto requestDto,
+            @AuthenticationPrincipal CustomOAuth2User user) {
+
+        Long userId = user.getUserId();
+        contestPostService.joinContest(requestDto, userId);
+
+        return ApiUtil.success("콘테스트 참여에 성공했습니다!");
+    }
+
+    @DeleteMapping("/{postId}")
+    public ApiSuccess<?> deletePost(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User user) {
+        Long userId = user.getUserId();
+        contestPostService.deletePost(postId, userId);
+
+        return ApiUtil.success("포스트 삭제가 완료되었습니다.");
+    }
+
+    @PostMapping("/{postId}/like")
+    public ApiSuccess<?> likePost(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User user) {
+        Long userId = user.getUserId();
+        contestPostLikeService.likePost(postId, userId);
+
+        return ApiUtil.success("해당 게시물에 좋아요를 눌렀습니다");
+    }
+
+    @DeleteMapping("/{postId}/like")
+    public ApiSuccess<?> unlikePost(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User user) {
+        Long userId = user.getUserId();
+        contestPostLikeService.unlikePost(postId, userId);
+
+        return ApiUtil.success("좋아요를 취소했습니다.");
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/ContestDetailDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/ContestDetailDto.java
@@ -1,0 +1,29 @@
+package com.dangdangsalon.domain.contest.dto;
+
+
+import com.dangdangsalon.domain.contest.entity.Contest;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ContestDetailDto {
+
+    private Long contestId;
+    private String title;
+    private LocalDateTime startedAt;
+    private LocalDateTime endAt;
+    private SimpleWinnerInfoDto recentWinner;
+
+    public static ContestDetailDto create(Contest nowContest, SimpleWinnerInfoDto previousWinner) {
+        return ContestDetailDto.builder()
+                .contestId(nowContest.getId())
+                .title(nowContest.getTitle())
+                .startedAt(nowContest.getStartedAt())
+                .endAt(nowContest.getEndAt())
+                .recentWinner(previousWinner)
+                .build();
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/ContestInfoDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/ContestInfoDto.java
@@ -1,0 +1,25 @@
+package com.dangdangsalon.domain.contest.dto;
+
+import com.dangdangsalon.domain.contest.entity.Contest;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ContestInfoDto {
+
+    private Long contestId;
+    private String title;
+    private LocalDateTime startedAt;
+    private LocalDateTime endAt;
+
+    public static ContestInfoDto fromEntity(Contest contest) {
+        return ContestInfoDto.builder()
+                .contestId(contest.getId())
+                .title(contest.getTitle())
+                .startedAt(contest.getStartedAt())
+                .endAt(contest.getEndAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/ContestJoinRequestDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/ContestJoinRequestDto.java
@@ -1,12 +1,16 @@
 package com.dangdangsalon.domain.contest.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class ContestJoinRequestDto {
+
+    @JsonProperty("groomer_profile_id")
     private Long groomerProfileId;
+
     private String dogName;
     private String imageUrl;
     private String description;

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/ContestJoinRequestDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/ContestJoinRequestDto.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 @Builder
 public class ContestJoinRequestDto {
 
+    private Long contestId;
+
     @JsonProperty("groomer_profile_id")
     private Long groomerProfileId;
 

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/ContestJoinRequestDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/ContestJoinRequestDto.java
@@ -11,7 +11,11 @@ public class ContestJoinRequestDto {
     @JsonProperty("groomer_profile_id")
     private Long groomerProfileId;
 
+    @JsonProperty("dog_name")
     private String dogName;
+
+    @JsonProperty("image_url")
     private String imageUrl;
+
     private String description;
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/ContestJoinRequestDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/ContestJoinRequestDto.java
@@ -1,0 +1,13 @@
+package com.dangdangsalon.domain.contest.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ContestJoinRequestDto {
+    private Long groomerProfileId;
+    private String dogName;
+    private String imageUrl;
+    private String description;
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/LastContestWinnerDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/LastContestWinnerDto.java
@@ -1,0 +1,25 @@
+package com.dangdangsalon.domain.contest.dto;
+
+import com.dangdangsalon.domain.contest.entity.Contest;
+import com.dangdangsalon.domain.contest.entity.ContestPost;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LastContestWinnerDto {
+
+    private Long contestId;
+    private Long grommerProfileId;
+    private PostInfoDto post;
+
+    public static LastContestWinnerDto fromEntity(Contest contest) {
+        ContestPost winnerPost = contest.getWinnerPost();
+
+        return LastContestWinnerDto.builder()
+                .contestId(contest.getId())
+                .grommerProfileId(winnerPost.getGroomerProfile().getId())
+                .post(PostInfoDto.create(winnerPost, false))
+                .build();
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/PostInfoDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/PostInfoDto.java
@@ -1,0 +1,31 @@
+package com.dangdangsalon.domain.contest.dto;
+
+import com.dangdangsalon.domain.contest.entity.ContestPost;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostInfoDto {
+
+    private Long postId;
+    private Long userId;
+    private String userName;
+    private String dogName;
+    private String imageUrl;
+    private String description;
+    private LocalDateTime createdAt;
+
+    public static PostInfoDto fromEntity(ContestPost post) {
+        return PostInfoDto.builder()
+                .postId(post.getId())
+                .userId(post.getUser().getId())
+                .userName(post.getUser().getName())
+                .dogName(post.getDogName())
+                .imageUrl(post.getImageKey())
+                .description(post.getDescription())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/PostInfoDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/PostInfoDto.java
@@ -16,8 +16,9 @@ public class PostInfoDto {
     private String imageUrl;
     private String description;
     private LocalDateTime createdAt;
+    private boolean isLiked;
 
-    public static PostInfoDto fromEntity(ContestPost post) {
+    public static PostInfoDto create(ContestPost post, boolean isLiked) {
         return PostInfoDto.builder()
                 .postId(post.getId())
                 .userId(post.getUser().getId())
@@ -26,6 +27,7 @@ public class PostInfoDto {
                 .imageUrl(post.getImageKey())
                 .description(post.getDescription())
                 .createdAt(post.getCreatedAt())
+                .isLiked(isLiked)
                 .build();
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/PostRankDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/PostRankDto.java
@@ -1,0 +1,35 @@
+package com.dangdangsalon.domain.contest.dto;
+
+import com.dangdangsalon.domain.contest.entity.ContestPost;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostRankDto {
+
+    private Long postId;
+    private Long userId;
+    private String dogName;
+    private String imageUrl;
+    private Long likeCount;
+
+    public PostRankDto(Long postId, Long userId, String dogName, String imageUrl, Long likeCount) {
+        this.postId = postId;
+        this.userId = userId;
+        this.dogName = dogName;
+        this.imageUrl = imageUrl;
+        this.likeCount = likeCount;
+    }
+
+    public static PostRankDto create(ContestPost post, Long likeCount) {
+        return PostRankDto.builder()
+                .postId(post.getId())
+                .userId(post.getUser().getId())
+                .dogName(post.getGroomerProfile().getName())
+                .imageUrl(post.getImageKey())
+                .likeCount(likeCount)
+                .build();
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/SimpleWinnerInfoDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/SimpleWinnerInfoDto.java
@@ -1,0 +1,23 @@
+package com.dangdangsalon.domain.contest.dto;
+
+import com.dangdangsalon.domain.contest.entity.ContestPost;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SimpleWinnerInfoDto {
+    private Long postId;
+    private String userName;
+    private String dogName;
+    private String imageUrl;
+
+    public static SimpleWinnerInfoDto fromEntity(ContestPost winnerPost) {
+        return SimpleWinnerInfoDto.builder()
+                .postId(winnerPost.getId())
+                .userName(winnerPost.getUser().getName())
+                .dogName(winnerPost.getDogName())
+                .imageUrl(winnerPost.getImageKey())
+                .build();
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/dto/WinnerRankDto.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/dto/WinnerRankDto.java
@@ -1,0 +1,22 @@
+package com.dangdangsalon.domain.contest.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WinnerRankDto {
+
+    private Long contestId;
+    private PostRankDto winnerPost;
+    private List<PostRankDto> rankPosts;
+
+    public static WinnerRankDto create(Long contestId, PostRankDto winnerPost, List<PostRankDto> rankPosts) {
+        return WinnerRankDto.builder()
+                .contestId(contestId)
+                .winnerPost(winnerPost)
+                .rankPosts(rankPosts)
+                .build();
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/entity/Contest.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/entity/Contest.java
@@ -49,4 +49,8 @@ public class Contest extends BaseEntity {
         this.winnerPost = winnerPost;
         this.contestPosts = contestPosts;
     }
+
+    public void updateWinner(ContestPost winnerPost) {
+        this.winnerPost = winnerPost;
+    }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/entity/Contest.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/entity/Contest.java
@@ -2,6 +2,8 @@ package com.dangdangsalon.domain.contest.entity;
 
 import com.dangdangsalon.config.base.BaseEntity;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,12 +35,18 @@ public class Contest extends BaseEntity {
     @JoinColumn(name = "winner_post_id", nullable = true)
     private ContestPost winnerPost;
 
+    @OneToMany(mappedBy = "contest", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<ContestPost> contestPosts = new ArrayList<>();
+
     @Builder
-    public Contest(String title, String description, LocalDateTime startedAt, LocalDateTime endAt, ContestPost winnerPost) {
+    public Contest(String title, String description, LocalDateTime startedAt, LocalDateTime endAt,
+                   ContestPost winnerPost,
+                   List<ContestPost> contestPosts) {
         this.title = title;
         this.description = description;
         this.startedAt = startedAt;
         this.endAt = endAt;
         this.winnerPost = winnerPost;
+        this.contestPosts = contestPosts;
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/entity/Contest.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/entity/Contest.java
@@ -35,7 +35,7 @@ public class Contest extends BaseEntity {
     @JoinColumn(name = "winner_post_id", nullable = true)
     private ContestPost winnerPost;
 
-    @OneToMany(mappedBy = "contest", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "contest", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ContestPost> contestPosts = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/dangdangsalon/domain/contest/entity/ContestPost.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/entity/ContestPost.java
@@ -30,9 +30,6 @@ public class ContestPost extends BaseEntity {
 
     private String description;
 
-    @Column(name = "like_count", columnDefinition = "INT DEFAULT 0")
-    private int likeCount;
-
     @ManyToOne
     @JoinColumn(name = "contest_id", nullable = false)
     private Contest contest;

--- a/src/main/java/com/dangdangsalon/domain/contest/entity/ContestPost.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/entity/ContestPost.java
@@ -43,12 +43,11 @@ public class ContestPost extends BaseEntity {
     private User user;
 
     @Builder
-    public ContestPost(String imageKey, String description, int likeCount, Contest contest,
+    public ContestPost(String imageKey, String description, Contest contest,
                        GroomerProfile groomerProfile,
                        User user) {
         this.imageKey = imageKey;
         this.description = description;
-        this.likeCount = likeCount;
         this.contest = contest;
         this.groomerProfile = groomerProfile;
         this.user = user;

--- a/src/main/java/com/dangdangsalon/domain/contest/entity/ContestPost.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/entity/ContestPost.java
@@ -26,6 +26,8 @@ public class ContestPost extends BaseEntity {
     @Column(name = "image_key")
     private String imageKey;
 
+    private String dogName;
+
     private String description;
 
     @Column(name = "like_count", columnDefinition = "INT DEFAULT 0")

--- a/src/main/java/com/dangdangsalon/domain/contest/entity/ContestPost.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/entity/ContestPost.java
@@ -30,15 +30,15 @@ public class ContestPost extends BaseEntity {
 
     private String description;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "contest_id", nullable = false)
     private Contest contest;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "groomer_profile_id", nullable = false)
     private GroomerProfile groomerProfile;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/com/dangdangsalon/domain/contest/entity/ContestPostLike.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/entity/ContestPostLike.java
@@ -1,0 +1,44 @@
+package com.dangdangsalon.domain.contest.entity;
+
+import com.dangdangsalon.config.base.BaseEntity;
+import com.dangdangsalon.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "post_like", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "contest_post_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ContestPostLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contest_post_id", nullable = false)
+    private ContestPost contestPost;
+
+    @Builder
+    public ContestPostLike(User user, ContestPost contestPost) {
+        this.user = user;
+        this.contestPost = contestPost;
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostLikeRepository.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostLikeRepository.java
@@ -10,4 +10,8 @@ public interface ContestPostLikeRepository extends JpaRepository<ContestPostLike
 
     @Query("SELECT pl.contestPost.id FROM ContestPostLike pl WHERE pl.user.id = :userId AND pl.contestPost.id IN :postIds")
     List<Long> findLikedPostIdsByUserId(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
+
+    boolean existsByUserIdAndContestPostId(Long userId, Long postId);
+
+    void deleteByUserIdAndContestPostId(Long userId, Long postId);
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostLikeRepository.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostLikeRepository.java
@@ -1,0 +1,13 @@
+package com.dangdangsalon.domain.contest.repository;
+
+import com.dangdangsalon.domain.contest.entity.ContestPostLike;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ContestPostLikeRepository extends JpaRepository<ContestPostLike, Long> {
+
+    @Query("SELECT pl.contestPost.id FROM ContestPostLike pl WHERE pl.user.id = :userId AND pl.contestPost.id IN :postIds")
+    List<Long> findLikedPostIdsByUserId(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostLikeRepository.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostLikeRepository.java
@@ -8,8 +8,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface ContestPostLikeRepository extends JpaRepository<ContestPostLike, Long> {
 
-    @Query("SELECT pl.contestPost.id FROM ContestPostLike pl WHERE pl.user.id = :userId AND pl.contestPost.id IN :postIds")
-    List<Long> findLikedPostIdsByUserId(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
+    @Query("SELECT COUNT(pl) FROM ContestPostLike pl WHERE pl.contestPost.id = :postId")
+    Long getLikeCountByPostId(@Param("postId") Long postId);
 
     boolean existsByUserIdAndContestPostId(Long userId, Long postId);
 

--- a/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostRepository.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostRepository.java
@@ -1,0 +1,11 @@
+package com.dangdangsalon.domain.contest.repository;
+
+import com.dangdangsalon.domain.contest.entity.ContestPost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContestPostRepository extends JpaRepository<ContestPost, Long> {
+
+    Page<ContestPost> findByContestId(Long contestId, Pageable pageable);
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostRepository.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostRepository.java
@@ -3,6 +3,7 @@ package com.dangdangsalon.domain.contest.repository;
 import com.dangdangsalon.domain.contest.dto.PostRankDto;
 import com.dangdangsalon.domain.contest.entity.ContestPost;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +23,11 @@ public interface ContestPostRepository extends JpaRepository<ContestPost, Long> 
             "GROUP BY p.id, p.user.id, gp.name, p.imageKey " +
             "ORDER BY COUNT(pl) DESC")
     List<PostRankDto> findTopRankPostsByContestId(@Param("contestId") Long contestId);
+
+    @Query("SELECT p FROM ContestPost p " +
+            "LEFT JOIN ContestPostLike l ON p.id = l.contestPost.id " +
+            "WHERE p.contest.id = :contestId " +
+            "GROUP BY p.id " +
+            "ORDER BY COUNT(l) DESC")
+    Optional<ContestPost> findTopLikedPostByContestId(@Param("contestId") Long contestId);
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostRepository.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostRepository.java
@@ -1,13 +1,25 @@
 package com.dangdangsalon.domain.contest.repository;
 
+import com.dangdangsalon.domain.contest.dto.PostRankDto;
 import com.dangdangsalon.domain.contest.entity.ContestPost;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ContestPostRepository extends JpaRepository<ContestPost, Long> {
 
     Page<ContestPost> findByContestId(Long contestId, Pageable pageable);
 
     boolean existsByContestIdAndUserId(Long contestId, Long userId);
+
+    @Query(value = "SELECT new com.dangdangsalon.domain.contest.dto.PostRankDto(p.id, p.user.id, p.dogName, p.imageKey, COUNT(pl)) " +
+            "FROM ContestPost p LEFT JOIN ContestPostLike pl ON p.id = pl.contestPost.id " +
+            "JOIN p.groomerProfile gp " +
+            "WHERE p.contest.id = :contestId " +
+            "GROUP BY p.id, p.user.id, gp.name, p.imageKey " +
+            "ORDER BY COUNT(pl) DESC")
+    List<PostRankDto> findTopRankPostsByContestId(@Param("contestId") Long contestId);
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostRepository.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/repository/ContestPostRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ContestPostRepository extends JpaRepository<ContestPost, Long> {
 
     Page<ContestPost> findByContestId(Long contestId, Pageable pageable);
+
+    boolean existsByContestIdAndUserId(Long contestId, Long userId);
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/repository/ContestRepository.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/repository/ContestRepository.java
@@ -1,0 +1,10 @@
+package com.dangdangsalon.domain.contest.repository;
+
+import com.dangdangsalon.domain.contest.entity.Contest;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContestRepository extends JpaRepository<Contest, Long> {
+
+    Optional<Contest> findTopByOrderByStartedAtDesc();
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/repository/ContestRepository.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/repository/ContestRepository.java
@@ -3,8 +3,12 @@ package com.dangdangsalon.domain.contest.repository;
 import com.dangdangsalon.domain.contest.entity.Contest;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ContestRepository extends JpaRepository<Contest, Long> {
 
     Optional<Contest> findTopByOrderByStartedAtDesc();
+
+    @Query("SELECT c FROM Contest c WHERE c.startedAt < (SELECT MAX(c2.startedAt) FROM Contest c2) ORDER BY c.startedAt DESC")
+    Optional<Contest> findPreviousContest();
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/scheduler/ContestScheduler.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/scheduler/ContestScheduler.java
@@ -1,0 +1,18 @@
+package com.dangdangsalon.domain.contest.scheduler;
+
+import com.dangdangsalon.domain.contest.service.ContestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ContestScheduler {
+
+    private final ContestService contestService;
+
+    @Scheduled(cron = "0 0 0 1 * ?") //매월 1일 자정에 실행
+    public void savePreviousContestWinner() {
+        contestService.savePreviousContestWinner();
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostLikeService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostLikeService.java
@@ -1,0 +1,57 @@
+package com.dangdangsalon.domain.contest.service;
+
+import com.dangdangsalon.domain.contest.entity.ContestPost;
+import com.dangdangsalon.domain.contest.entity.ContestPostLike;
+import com.dangdangsalon.domain.contest.repository.ContestPostLikeRepository;
+import com.dangdangsalon.domain.contest.repository.ContestPostRepository;
+import com.dangdangsalon.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ContestPostLikeService {
+
+    private final ContestPostRepository contestPostRepository;
+    private final ContestPostLikeRepository contestPostLikeRepository;
+
+    @Transactional
+    @CacheEvict(value = "likeStatus", key = "'like_status:' + #userId + ':' + #postId")
+    public void likePost(Long postId, Long userId) {
+        if (isValidLike(postId, userId)) {
+            throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
+        }
+
+        ContestPost post = contestPostRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 포스트가 존재하지 않습니다. postId: " + postId));
+
+        ContestPostLike like = ContestPostLike.builder()
+                .user(User.builder().id(userId).build())
+                .contestPost(post)
+                .build();
+
+        contestPostLikeRepository.save(like);
+    }
+
+    @Transactional
+    @CacheEvict(value = "likeStatus", key = "'like_status:' + #userId + ':' + #postId")
+    public void unlikePost(Long postId, Long userId) {
+        if (!isValidLike(postId, userId)) {
+            throw new IllegalStateException("좋아요를 누르지 않았습니다");
+        }
+
+        contestPostLikeRepository.deleteByUserIdAndContestPostId(userId, postId);
+    }
+
+    @Cacheable(value = "likeStatus", key = "'like_status:' + #userId + ':' + #postId")
+    public boolean checkIsLiked(Long postId, Long userId) {
+        return contestPostLikeRepository.existsByUserIdAndContestPostId(userId, postId);
+    }
+
+    private boolean isValidLike(Long postId, Long userId) {
+        return contestPostLikeRepository.existsByUserIdAndContestPostId(userId, postId);
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostLikeService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostLikeService.java
@@ -21,7 +21,7 @@ public class ContestPostLikeService {
     @Transactional
     @CacheEvict(value = "likeStatus", key = "'like_status:' + #userId + ':' + #postId")
     public void likePost(Long postId, Long userId) {
-        if (isValidLike(postId, userId)) {
+        if (isLike(postId, userId)) {
             throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
         }
 
@@ -39,7 +39,7 @@ public class ContestPostLikeService {
     @Transactional
     @CacheEvict(value = "likeStatus", key = "'like_status:' + #userId + ':' + #postId")
     public void unlikePost(Long postId, Long userId) {
-        if (!isValidLike(postId, userId)) {
+        if (!isLike(postId, userId)) {
             throw new IllegalStateException("좋아요를 누르지 않았습니다");
         }
 
@@ -51,7 +51,7 @@ public class ContestPostLikeService {
         return contestPostLikeRepository.existsByUserIdAndContestPostId(userId, postId);
     }
 
-    private boolean isValidLike(Long postId, Long userId) {
+    private boolean isLike(Long postId, Long userId) {
         return contestPostLikeRepository.existsByUserIdAndContestPostId(userId, postId);
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostService.java
@@ -1,0 +1,76 @@
+package com.dangdangsalon.domain.contest.service;
+
+import com.dangdangsalon.domain.contest.dto.ContestJoinRequestDto;
+import com.dangdangsalon.domain.contest.dto.PostInfoDto;
+import com.dangdangsalon.domain.contest.entity.Contest;
+import com.dangdangsalon.domain.contest.entity.ContestPost;
+import com.dangdangsalon.domain.contest.repository.ContestPostLikeRepository;
+import com.dangdangsalon.domain.contest.repository.ContestPostRepository;
+import com.dangdangsalon.domain.contest.repository.ContestRepository;
+import com.dangdangsalon.domain.groomerprofile.entity.GroomerProfile;
+import com.dangdangsalon.domain.groomerprofile.repository.GroomerProfileRepository;
+import com.dangdangsalon.domain.user.entity.User;
+import com.dangdangsalon.domain.user.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ContestPostService {
+
+    private final ContestRepository contestRepository;
+    private final ContestPostRepository contestPostRepository;
+    private final ContestPostLikeRepository contestPostLikeRepository;
+    private final GroomerProfileRepository groomerProfileRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public Page<PostInfoDto> getContestPosts(Long contestId, Long userId, Pageable pageable) {
+        Page<ContestPost> posts = contestPostRepository.findByContestId(contestId, pageable);
+
+        List<Long> postIds = posts.getContent().stream()
+                .map(ContestPost::getId)
+                .toList();
+
+        List<Long> likedPostIds = contestPostLikeRepository.findLikedPostIdsByUserId(userId, postIds);
+
+        return posts.map(post -> {
+            boolean isLiked = likedPostIds.contains(post.getId());
+            return PostInfoDto.create(post, isLiked);
+        });
+    }
+
+    @Transactional
+    public void joinContest(Long contestId, ContestJoinRequestDto requestDto, Long userId) {
+        Contest contest = contestRepository.findById(contestId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 콘테스트가 없습니다. InputId: " + contestId));
+
+        GroomerProfile groomerProfile = groomerProfileRepository.findById(requestDto.getGroomerProfileId())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "해당하는 미용사 프로필이 없습니다. InputId: " + requestDto.getGroomerProfileId()));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 유저가 없습니다. InputId: " + userId));
+
+        if (isAlreadyJoined(contestId, userId)) {
+            throw new IllegalStateException("이미 해당 콘테스트에 참여하셨습니다.");
+        }
+
+        ContestPost joinPost = ContestPost.builder()
+                .imageKey(requestDto.getImageUrl())
+                .description(requestDto.getDescription())
+                .contest(contest)
+                .groomerProfile(groomerProfile)
+                .user(user)
+                .build();
+
+        contestPostRepository.save(joinPost);
+    }
+
+    private boolean isAlreadyJoined(Long contestId, Long userId) {
+        return contestPostRepository.existsByContestIdAndUserId(contestId, userId);
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostService.java
@@ -24,22 +24,17 @@ public class ContestPostService {
 
     private final ContestRepository contestRepository;
     private final ContestPostRepository contestPostRepository;
-    private final ContestPostLikeRepository contestPostLikeRepository;
     private final GroomerProfileRepository groomerProfileRepository;
     private final UserRepository userRepository;
+
+    private final ContestPostLikeService contestPostLikeService;
 
     @Transactional(readOnly = true)
     public Page<PostInfoDto> getContestPosts(Long contestId, Long userId, Pageable pageable) {
         Page<ContestPost> posts = contestPostRepository.findByContestId(contestId, pageable);
 
-        List<Long> postIds = posts.getContent().stream()
-                .map(ContestPost::getId)
-                .toList();
-
-        List<Long> likedPostIds = contestPostLikeRepository.findLikedPostIdsByUserId(userId, postIds);
-
         return posts.map(post -> {
-            boolean isLiked = likedPostIds.contains(post.getId());
+            boolean isLiked = contestPostLikeService.checkIsLiked(userId, post.getId());
             return PostInfoDto.create(post, isLiked);
         });
     }

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostService.java
@@ -70,7 +70,22 @@ public class ContestPostService {
         contestPostRepository.save(joinPost);
     }
 
+    public void deletePost(Long postId, Long userId) {
+        ContestPost post = contestPostRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 포스트가 존재하지 않습니다. InputId: " + postId));
+
+        if (isInValidUser(userId, post)) {
+            throw new IllegalStateException("작성자가 아닙니다.");
+        }
+
+        contestPostRepository.delete(post);
+    }
+
     private boolean isAlreadyJoined(Long contestId, Long userId) {
         return contestPostRepository.existsByContestIdAndUserId(contestId, userId);
+    }
+
+    private static boolean isInValidUser(Long userId, ContestPost post) {
+        return !post.getUser().getId().equals(userId);
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostService.java
@@ -45,9 +45,10 @@ public class ContestPostService {
     }
 
     @Transactional
-    public void joinContest(Long contestId, ContestJoinRequestDto requestDto, Long userId) {
-        Contest contest = contestRepository.findById(contestId)
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 콘테스트가 없습니다. InputId: " + contestId));
+    public void joinContest(ContestJoinRequestDto requestDto, Long userId) {
+        Contest contest = contestRepository.findById(requestDto.getContestId())
+                .orElseThrow(
+                        () -> new IllegalArgumentException("해당하는 콘테스트가 없습니다. InputId: " + requestDto.getContestId()));
 
         GroomerProfile groomerProfile = groomerProfileRepository.findById(requestDto.getGroomerProfileId())
                 .orElseThrow(() -> new IllegalArgumentException(
@@ -55,7 +56,7 @@ public class ContestPostService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 유저가 없습니다. InputId: " + userId));
 
-        if (isAlreadyJoined(contestId, userId)) {
+        if (isAlreadyJoined(requestDto.getContestId(), userId)) {
             throw new IllegalStateException("이미 해당 콘테스트에 참여하셨습니다.");
         }
 
@@ -70,6 +71,7 @@ public class ContestPostService {
         contestPostRepository.save(joinPost);
     }
 
+    @Transactional
     public void deletePost(Long postId, Long userId) {
         ContestPost post = contestPostRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 포스트가 존재하지 않습니다. InputId: " + postId));

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
@@ -51,6 +51,7 @@ public class ContestService {
         return ContestDetailDto.create(nowContest, previousWinnerDto);
     }
 
+    @Transactional(readOnly = true)
     public boolean checkUserParticipated(Long contestId, Long userId) {
         return contestPostRepository.existsByContestIdAndUserId(contestId, userId);
     }

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
@@ -11,6 +11,7 @@ import com.dangdangsalon.domain.contest.entity.ContestPost;
 import com.dangdangsalon.domain.contest.repository.ContestPostLikeRepository;
 import com.dangdangsalon.domain.contest.repository.ContestPostRepository;
 import com.dangdangsalon.domain.contest.repository.ContestRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -85,5 +86,16 @@ public class ContestService {
         List<PostRankDto> rankPosts = contestPostRepository.findTopRankPostsByContestId(previousContest.getId());
 
         return WinnerRankDto.create(previousContest.getId(), winnerDto, rankPosts);
+    }
+
+    @Transactional
+    public void savePreviousContestWinner() {
+        Contest previousContest = contestRepository.findPreviousContest()
+                .orElseThrow(() -> new IllegalArgumentException("지난 달에 진행된 콘테스트가 없습니다."));
+
+        ContestPost winnerPost = contestPostRepository.findTopLikedPostByContestId(previousContest.getId())
+                .orElseThrow(() -> new IllegalArgumentException("지난 달 콘테스트에 포스트가 없습니다."));
+
+        previousContest.updateWinner(winnerPost);
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
@@ -1,9 +1,17 @@
 package com.dangdangsalon.domain.contest.service;
 
+import com.dangdangsalon.domain.contest.dto.ContestDetailDto;
 import com.dangdangsalon.domain.contest.dto.ContestInfoDto;
+import com.dangdangsalon.domain.contest.dto.PostInfoDto;
+import com.dangdangsalon.domain.contest.dto.SimpleWinnerInfoDto;
 import com.dangdangsalon.domain.contest.entity.Contest;
+import com.dangdangsalon.domain.contest.entity.ContestPost;
+import com.dangdangsalon.domain.contest.repository.ContestPostRepository;
 import com.dangdangsalon.domain.contest.repository.ContestRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ContestService {
 
     private final ContestRepository contestRepository;
+    private final ContestPostRepository contestPostRepository;
 
     @Transactional(readOnly = true)
     public ContestInfoDto getLatestContest() {
@@ -19,5 +28,28 @@ public class ContestService {
                 .orElseThrow(() -> new IllegalArgumentException("진행중인 콘테스트가 없습니다."));
 
         return ContestInfoDto.fromEntity(latestContest);
+    }
+
+    @Transactional(readOnly = true)
+    public ContestDetailDto getContestDetails(Long contestId) {
+        Contest nowContest = contestRepository.findById(contestId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 콘테스트가 없습니다. InputId: " + contestId));
+
+        Contest previousContest = contestRepository.findPreviousContest()
+                .orElseThrow(() -> new IllegalArgumentException("이전 콘테스트가 없습니다."));
+
+        SimpleWinnerInfoDto previousWinnerDto = null;
+
+        if (previousContest.getWinnerPost() != null) {
+            previousWinnerDto = SimpleWinnerInfoDto.fromEntity(previousContest.getWinnerPost());
+        }
+
+        return ContestDetailDto.create(nowContest, previousWinnerDto);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PostInfoDto> getContestPosts(Long contestId, Pageable pageable) {
+        return contestPostRepository.findByContestId(contestId, pageable)
+                .map(PostInfoDto::fromEntity);
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
@@ -1,0 +1,23 @@
+package com.dangdangsalon.domain.contest.service;
+
+import com.dangdangsalon.domain.contest.dto.ContestInfoDto;
+import com.dangdangsalon.domain.contest.entity.Contest;
+import com.dangdangsalon.domain.contest.repository.ContestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ContestService {
+
+    private final ContestRepository contestRepository;
+
+    @Transactional(readOnly = true)
+    public ContestInfoDto getLatestContest() {
+        Contest latestContest = contestRepository.findTopByOrderByStartedAtDesc()
+                .orElseThrow(() -> new IllegalArgumentException("진행중인 콘테스트가 없습니다."));
+
+        return ContestInfoDto.fromEntity(latestContest);
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
@@ -2,6 +2,7 @@ package com.dangdangsalon.domain.contest.service;
 
 import com.dangdangsalon.domain.contest.dto.ContestDetailDto;
 import com.dangdangsalon.domain.contest.dto.ContestInfoDto;
+import com.dangdangsalon.domain.contest.dto.ContestJoinRequestDto;
 import com.dangdangsalon.domain.contest.dto.PostInfoDto;
 import com.dangdangsalon.domain.contest.dto.SimpleWinnerInfoDto;
 import com.dangdangsalon.domain.contest.entity.Contest;
@@ -9,6 +10,8 @@ import com.dangdangsalon.domain.contest.entity.ContestPost;
 import com.dangdangsalon.domain.contest.repository.ContestPostLikeRepository;
 import com.dangdangsalon.domain.contest.repository.ContestPostRepository;
 import com.dangdangsalon.domain.contest.repository.ContestRepository;
+import com.dangdangsalon.domain.groomerprofile.entity.GroomerProfile;
+import com.dangdangsalon.domain.groomerprofile.repository.GroomerProfileRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,8 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class ContestService {
 
     private final ContestRepository contestRepository;
-    private final ContestPostRepository contestPostRepository;
-    private final ContestPostLikeRepository contestPostLikeRepository;
 
     @Transactional(readOnly = true)
     public ContestInfoDto getLatestContest() {
@@ -47,21 +48,5 @@ public class ContestService {
         }
 
         return ContestDetailDto.create(nowContest, previousWinnerDto);
-    }
-
-    @Transactional(readOnly = true)
-    public Page<PostInfoDto> getContestPosts(Long contestId, Long userId, Pageable pageable) {
-        Page<ContestPost> posts = contestPostRepository.findByContestId(contestId, pageable);
-
-        List<Long> postIds = posts.getContent().stream()
-                .map(ContestPost::getId)
-                .toList();
-
-        List<Long> likedPostIds = contestPostLikeRepository.findLikedPostIdsByUserId(userId, postIds);
-
-        return posts.map(post -> {
-            boolean isLiked = likedPostIds.contains(post.getId());
-            return PostInfoDto.create(post, isLiked);
-        });
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ContestService {
 
     private final ContestRepository contestRepository;
+    private final ContestPostRepository contestPostRepository;
 
     @Transactional(readOnly = true)
     public ContestInfoDto getLatestContest() {
@@ -48,5 +49,9 @@ public class ContestService {
         }
 
         return ContestDetailDto.create(nowContest, previousWinnerDto);
+    }
+
+    public boolean checkUserParticipated(Long contestId, Long userId) {
+        return contestPostRepository.existsByContestIdAndUserId(contestId, userId);
     }
 }

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestService.java
@@ -14,6 +14,7 @@ import com.dangdangsalon.domain.contest.repository.ContestRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,6 +65,7 @@ public class ContestService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "winnerRank", key = "'getWinnerAndRankPost'")
     public WinnerRankDto getWinnerAndRankPost() {
         Contest previousContest = contestRepository.findPreviousContest()
                 .orElseThrow(() -> new IllegalArgumentException("지난 콘테스트가 없습니다."));

--- a/src/main/java/com/dangdangsalon/domain/groomerprofile/repository/GroomerProfileRepository.java
+++ b/src/main/java/com/dangdangsalon/domain/groomerprofile/repository/GroomerProfileRepository.java
@@ -1,0 +1,7 @@
+package com.dangdangsalon.domain.groomerprofile.repository;
+
+import com.dangdangsalon.domain.groomerprofile.entity.GroomerProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroomerProfileRepository extends JpaRepository<GroomerProfile, Long> {
+}

--- a/src/main/java/com/dangdangsalon/domain/s3image/controller/ImageController.java
+++ b/src/main/java/com/dangdangsalon/domain/s3image/controller/ImageController.java
@@ -1,0 +1,25 @@
+package com.dangdangsalon.domain.s3image.controller;
+
+import com.dangdangsalon.domain.s3image.service.ImageService;
+import com.dangdangsalon.util.ApiUtil;
+import com.dangdangsalon.util.ApiUtil.ApiSuccess;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    public ApiSuccess<?> uploadImage(@RequestParam("file") MultipartFile file) {
+        String imageUrl = imageService.uploadImage(file);
+        return ApiUtil.success(imageUrl);
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/s3image/service/ImageService.java
+++ b/src/main/java/com/dangdangsalon/domain/s3image/service/ImageService.java
@@ -1,0 +1,21 @@
+package com.dangdangsalon.domain.s3image.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Service s3Service;
+
+    @Value("${cloud.aws.cloudfront.domain}")
+    private String cloudFrontDomain;
+
+    public String uploadImage(MultipartFile file) {
+        String fileName = s3Service.uploadFile(file);
+        return String.format("https://%s/%s", cloudFrontDomain, fileName);
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/s3image/service/S3Service.java
+++ b/src/main/java/com/dangdangsalon/domain/s3image/service/S3Service.java
@@ -1,0 +1,47 @@
+package com.dangdangsalon.domain.s3image.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String uploadFile(MultipartFile file) {
+        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        File convertedFile = convertMultipartFileToFile(file);
+
+        try {
+            s3Client.putObject(new PutObjectRequest(bucketName, fileName, convertedFile));
+            return fileName;
+        } finally {
+            if (convertedFile.exists()) {
+                convertedFile.delete();
+            }
+        }
+    }
+
+    private File convertMultipartFileToFile(MultipartFile file) {
+        File convertedFile = new File(Objects.requireNonNull(file.getOriginalFilename()));
+        try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
+            fos.write(file.getBytes());
+        } catch (IOException e) {
+            throw new RuntimeException("파일 변환 중 오류 발생", e);
+        }
+        return convertedFile;
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/user/entity/User.java
+++ b/src/main/java/com/dangdangsalon/domain/user/entity/User.java
@@ -45,12 +45,6 @@ public class User extends BaseEntity {
         this.district = district;
     }
 
-    public void updateData(String name, String email, String profileImage) {
-        this.name = name;
-        this.email = email;
-        this.imageKey = profileImage;
-    }
-
     public void updateAdditionalInfo(Role role, District district) {
         this.role = role;
         this.district = district;

--- a/src/main/java/com/dangdangsalon/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/dangdangsalon/exception/handler/GlobalExceptionHandler.java
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(TokenExpiredException.class)
     protected ResponseEntity<?> handleExpiredJwtException(TokenExpiredException e) {
-        ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_NOT_FOUND, e.getMessage());
+        ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
         return ResponseEntity.status(HttpServletResponse.SC_UNAUTHORIZED).body(error);
     }
 }

--- a/src/main/java/com/dangdangsalon/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/dangdangsalon/exception/handler/GlobalExceptionHandler.java
@@ -34,6 +34,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(HttpServletResponse.SC_NOT_FOUND).body(error);
     }
 
+    @ExceptionHandler({
+            IllegalStateException.class
+    })
+    protected ResponseEntity<?> handleIllegalStateException(Exception e) {
+        ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_FORBIDDEN, e.getMessage());
+        return ResponseEntity.status(HttpServletResponse.SC_FORBIDDEN).body(error);
+    }
+
     @ExceptionHandler(TokenExpiredException.class)
     protected ResponseEntity<?> handleExpiredJwtException(TokenExpiredException e) {
         ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_NOT_FOUND, e.getMessage());

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -81,3 +81,10 @@ spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kak
 spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
 spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 spring.security.oauth2.client.provider.kakao.user-name-attribute=properties
+
+##AWS S3
+cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
+cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.s3.bucket=dangdangserver-bucket
+cloud.aws.cloudfront.domain=${AWS_CLOUDFRONT_DOMAIN}

--- a/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1__initial_schema.sql
@@ -165,6 +165,7 @@ CREATE TABLE `contest_post`
     `created_at`         datetime(6) DEFAULT NULL,
     `updated_at`         datetime(6) DEFAULT NULL,
     `description`        varchar(255) DEFAULT NULL,
+    `dog_name`           varchar(255) DEFAULT NULL,
     `image_key`          varchar(255) DEFAULT NULL,
     `like_count`         int          DEFAULT '0',
     `contest_id`         bigint       DEFAULT NULL,

--- a/src/main/resources/db/migration/V5__add_post_like.sql
+++ b/src/main/resources/db/migration/V5__add_post_like.sql
@@ -1,0 +1,13 @@
+CREATE TABLE post_like
+(
+    id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id         BIGINT NOT NULL,
+    contest_post_id BIGINT NOT NULL,
+    `created_at`    datetime(6) DEFAULT NULL,
+    `updated_at`    datetime(6) DEFAULT NULL,
+    UNIQUE (user_id, contest_post_id),
+    FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE,
+    FOREIGN KEY (contest_post_id) REFERENCES contest_post (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+ALTER TABLE contest_post DROP COLUMN like_count;


### PR DESCRIPTION
## 🔍 연관된 이슈

> ex) #25 

## 🔀 작업 내용

- [x] 콘테스트 조회
- [x] 콘테스트 상세 조회 (캐시)
- [x] 콘테스트 참여 - 포스트 등록
- [x] 콘테스트 포스트 삭제
- [x] 콘테스트 중복참여 체크
- [x] 콘테스트 포스트 좋아요/좋아요 취소 (캐시)
- [x] 콘테스트 우승자 저장 및 조회
- [x] 이미지 사용 시 S3 사용할 수 있도록 구현

V1에 ContestPost dogName 필드 추가.
V5에 ContestPostLike 테이블 추가 및 ContestPost에 likeCount 필드 삭제

### 📸 스크린샷 or 영상(선택)

- 콘테스트 조회
![image](https://github.com/user-attachments/assets/616fd5c3-66d0-4668-aa87-af032c89cb43)

- 콘테스트 상세 조회
![image](https://github.com/user-attachments/assets/a256d92b-d428-464d-a6ba-dc36b2c2e935)

- 콘테스트 상세조회 (포스트)
![image](https://github.com/user-attachments/assets/a9d47d54-aa9d-499c-8f63-25b832b317d6)

- 콘테스트 참가 (포스트 등록)
![image](https://github.com/user-attachments/assets/bd3442cd-8104-44db-a0f4-e0867d1428b5)

- 콘테스트 포스트 삭제
![image](https://github.com/user-attachments/assets/dfa91500-0369-477c-aa06-88a47f4251bb)

- 콘테스트 참여 중복체크
![image](https://github.com/user-attachments/assets/701542af-975a-4018-859c-e7e2f0e39db6)

- 콘테스트 포스트 좋아요/좋아요 취소

![image](https://github.com/user-attachments/assets/427fa147-effc-4d8e-b5ae-3f141ebda864)
![image](https://github.com/user-attachments/assets/03889372-45e9-4982-9ffa-195623d194e1)
![image](https://github.com/user-attachments/assets/90fbc6c5-c28e-47cb-b318-7ea4ecc74c4b)

- 콘테스트 상세조회 (포스트 + 캐시) -> 매번 좋아요를 눌렀는지 Repository에서 조회해야 하는데, 그 부분을 줄여줄 수 있다.

![image](https://github.com/user-attachments/assets/b102ad1b-4bff-4ca1-8f32-b83a7573c250)

- 지난달 콘테스트 우승자 조회

![image](https://github.com/user-attachments/assets/8d7e0e0d-1368-40e9-9cbe-e83bb7d360a1)

- 지난달 콘테스트 기타 랭킹 조회

![image](https://github.com/user-attachments/assets/f1076100-14af-421b-95d5-c85e8a896189)

- S3 이미지 업로드

![image](https://github.com/user-attachments/assets/93a59169-ac5e-4b2e-8147-3f30188cf9fd)


## 🧐 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
