### PR TITLE
Refactor: 지역 id 및 미용사 프로필 등록 필수, 선택 필드 변경

### DIFF
--- a/src/main/java/com/dangdangsalon/domain/groomerprofile/entity/GroomerProfile.java
+++ b/src/main/java/com/dangdangsalon/domain/groomerprofile/entity/GroomerProfile.java
@@ -88,8 +88,7 @@ public class GroomerProfile extends BaseEntity {
         this.user = user;
     }
 
-    public void updateProfileDetail(ServiceType serviceType, String imageKey, GroomerDetails details) {
-        this.serviceType = serviceType;
+    public void updateProfileDetail(String imageKey, GroomerDetails details) {
         this.imageKey = imageKey;
         this.details = details;
     }
@@ -113,6 +112,7 @@ public class GroomerProfile extends BaseEntity {
                 .name(requestDto.getName())
                 .phone(requestDto.getPhone())
                 .contactHours(requestDto.getContactHours())
+                .serviceType(requestDto.getServiceType())
                 .details(null)
                 .user(user)
                 .build();

--- a/src/main/java/com/dangdangsalon/domain/groomerprofile/repository/GroomerProfileRepository.java
+++ b/src/main/java/com/dangdangsalon/domain/groomerprofile/repository/GroomerProfileRepository.java
@@ -26,7 +26,7 @@ public interface GroomerProfileRepository extends JpaRepository<GroomerProfile, 
     Optional<GroomerProfile> findByUserIdWithDistrict(@Param("userId") Long userId);
 
     @Query("SELECT new com.dangdangsalon.domain.mypage.dto.res.DistrictResponseDto" +
-            "(d.name, c.name) " +
+            "(d.id, d.name, c.name) " +
             "FROM GroomerServiceArea gsa " +
             "JOIN gsa.district d " +
             "JOIN d.city c " +

--- a/src/main/java/com/dangdangsalon/domain/mypage/controller/MyPageGroomerController.java
+++ b/src/main/java/com/dangdangsalon/domain/mypage/controller/MyPageGroomerController.java
@@ -42,7 +42,7 @@ public class MyPageGroomerController {
     }
 
     @PostMapping("/detail")
-    public ApiSuccess<?> saveGroomerProfileDetail(@RequestBody GroomerProfileDetailsRequestDto requestDto,
+    public ApiSuccess<?> saveGroomerProfile(@RequestBody GroomerProfileDetailsRequestDto requestDto,
                                             @AuthenticationPrincipal CustomOAuth2User user) {
         Long userId = user.getUserId();
         myPageGroomerService.saveGroomerProfileDetails(requestDto, userId);
@@ -55,7 +55,7 @@ public class MyPageGroomerController {
                                                   @PathVariable Long profileId) {
         Long userId = user.getUserId();
         myPageGroomerService.updateGroomerProfile(requestDto, userId, profileId);
-        return ApiUtil.success("미용사 프로필 상세 정보 등록이 완료되었습니다.");
+        return ApiUtil.success("미용사 프로필 정보 수정이 완료되었습니다.");
     }
 
     @DeleteMapping("/{profileId}")

--- a/src/main/java/com/dangdangsalon/domain/mypage/dto/req/GroomerProfileDetailsRequestDto.java
+++ b/src/main/java/com/dangdangsalon/domain/mypage/dto/req/GroomerProfileDetailsRequestDto.java
@@ -15,7 +15,6 @@ import java.util.List;
 // 미용사 회원가입 설정 2 (요청)
 public class GroomerProfileDetailsRequestDto {
     private String imageKey;
-    private ServiceType serviceType;
     private String businessNumber;
     private String address;
     private String experience;
@@ -23,5 +22,4 @@ public class GroomerProfileDetailsRequestDto {
     private String startMessage;
     private String faq;
     private List<String> certifications;
-    private List<Long> servicesDistrictIds;
 }

--- a/src/main/java/com/dangdangsalon/domain/mypage/dto/req/GroomerProfileRequestDto.java
+++ b/src/main/java/com/dangdangsalon/domain/mypage/dto/req/GroomerProfileRequestDto.java
@@ -1,5 +1,6 @@
 package com.dangdangsalon.domain.mypage.dto.req;
 
+import com.dangdangsalon.domain.groomerprofile.entity.ServiceType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +16,8 @@ import java.util.List;
 public class GroomerProfileRequestDto {
     private String name;
     private String phone;
-    private List<Long> servicesOfferedId;
     private String contactHours;
+    private ServiceType serviceType;
+    private List<Long> servicesOfferedId;
+    private List<Long> servicesDistrictIds;
 }

--- a/src/main/java/com/dangdangsalon/domain/mypage/dto/res/CommonProfileResponseDto.java
+++ b/src/main/java/com/dangdangsalon/domain/mypage/dto/res/CommonProfileResponseDto.java
@@ -13,6 +13,7 @@ public class CommonProfileResponseDto {
     private String imageKey;
     private String name;
     private String email;
+    private Long districtId;
     private String district;
     private String city;
 
@@ -21,6 +22,7 @@ public class CommonProfileResponseDto {
                 .imageKey(user.getImageKey())
                 .name(user.getName())
                 .email(user.getEmail())
+                .districtId(user.getDistrict().getId())
                 .city(user.getDistrict().getCity().getName())
                 .district(user.getDistrict().getName())
                 .build();

--- a/src/main/java/com/dangdangsalon/domain/mypage/dto/res/DistrictResponseDto.java
+++ b/src/main/java/com/dangdangsalon/domain/mypage/dto/res/DistrictResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Builder
 // 미용사 서비스 지역 (응답)
 public class DistrictResponseDto {
+    private Long districtId;
     private String district;
     private String city;
 }

--- a/src/main/java/com/dangdangsalon/domain/mypage/dto/res/UserProfileResponseDto.java
+++ b/src/main/java/com/dangdangsalon/domain/mypage/dto/res/UserProfileResponseDto.java
@@ -18,8 +18,9 @@ public class UserProfileResponseDto {
     private String name;
     private String email;
     private String profileImage;
-    private String city;
+    private Long districtId;
     private String district;
+    private String city;
     private List<DogProfileResponseDto> dogProfiles;
     private long couponCount;
     private long reviewCount;
@@ -31,6 +32,7 @@ public class UserProfileResponseDto {
                 .name(user.getName())
                 .email(user.getEmail())
                 .profileImage(user.getImageKey())
+                .districtId(user.getDistrict().getId())
                 .city(user.getDistrict().getCity().getName())
                 .district(user.getDistrict().getName())
                 .dogProfiles(

--- a/src/main/java/com/dangdangsalon/domain/mypage/service/MyPageGroomerService.java
+++ b/src/main/java/com/dangdangsalon/domain/mypage/service/MyPageGroomerService.java
@@ -151,23 +151,7 @@ public class MyPageGroomerService {
             }
             addCanService(services, groomerProfile);
         }
-    }
 
-
-    @Transactional
-    public void saveGroomerProfileDetails(GroomerProfileDetailsRequestDto requestDto, Long userId) {
-        GroomerProfile groomerProfile = groomerProfileRepository.findByUserIdWithDistrict(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 미용사를 찾을 수 없습니다."));
-
-        groomerProfile.updateProfileDetail(
-                requestDto.getServiceType(),
-                requestDto.getImageKey(),
-                GroomerDetails.createGroomerDetails(requestDto)
-        );
-
-        if (requestDto.getCertifications() != null && !requestDto.getCertifications().isEmpty()) {
-            addCertification(requestDto.getCertifications(), groomerProfile);
-        }
         // 요청에 포함된 서비스 ID로 GroomerService 리스트 조회
         if (requestDto.getServicesDistrictIds() != null && !requestDto.getServicesDistrictIds().isEmpty()) {
             List<District> districts = districtRepository.findAllById(requestDto.getServicesDistrictIds());
@@ -177,6 +161,23 @@ public class MyPageGroomerService {
                 throw new IllegalArgumentException("유효하지 않은 서비스 ID가 포함되어 있습니다.");
             }
             addDistrict(districts, groomerProfile);
+        }
+
+    }
+
+
+    @Transactional
+    public void saveGroomerProfileDetails(GroomerProfileDetailsRequestDto requestDto, Long userId) {
+        GroomerProfile groomerProfile = groomerProfileRepository.findByUserIdWithDistrict(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 미용사를 찾을 수 없습니다."));
+
+        groomerProfile.updateProfileDetail(
+                requestDto.getImageKey(),
+                GroomerDetails.createGroomerDetails(requestDto)
+        );
+
+        if (requestDto.getCertifications() != null && !requestDto.getCertifications().isEmpty()) {
+            addCertification(requestDto.getCertifications(), groomerProfile);
         }
     }
 

--- a/src/test/java/com/dangdangsalon/domain/mypage/api/MyPageApiTest.java
+++ b/src/test/java/com/dangdangsalon/domain/mypage/api/MyPageApiTest.java
@@ -228,7 +228,7 @@ public class MyPageApiTest {
                 .put("/api/groomerprofile/1")
                 .then()
                 .statusCode(200)
-                .body("response", equalTo("미용사 프로필 상세 정보 등록이 완료되었습니다."));
+                .body("response", equalTo("미용사 프로필 정보 수정이 완료되었습니다."));
     }
 
     @Test

--- a/src/test/java/com/dangdangsalon/domain/mypage/controller/MyPageCommonControllerTest.java
+++ b/src/test/java/com/dangdangsalon/domain/mypage/controller/MyPageCommonControllerTest.java
@@ -56,7 +56,7 @@ class MyPageCommonControllerTest {
 
         // 유저 프로필 데이터 예시
         CommonProfileResponseDto mockResponse = new CommonProfileResponseDto("imageKey",
-                "name", "email@example.com", "종로구", "서울시");
+                "name", "email@example.com", 1L, "종로구", "서울시");
         when(myPageCommonService.getUserinfo(mockUserId)).thenReturn(mockResponse);
 
         // GET 요청으로 유저 프로필 조회

--- a/src/test/java/com/dangdangsalon/domain/mypage/controller/MyPageGroomerControllerTest.java
+++ b/src/test/java/com/dangdangsalon/domain/mypage/controller/MyPageGroomerControllerTest.java
@@ -198,7 +198,7 @@ class MyPageGroomerControllerTest {
                         .with(csrf())
                         .principal(new UsernamePasswordAuthenticationToken(customOAuth2User, null)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.response").value("미용사 프로필 상세 정보 등록이 완료되었습니다."));
+                .andExpect(jsonPath("$.response").value("미용사 프로필 정보 수정이 완료되었습니다."));
     }
 
     @Test

--- a/src/test/java/com/dangdangsalon/domain/mypage/service/MyPageGroomerServiceTest.java
+++ b/src/test/java/com/dangdangsalon/domain/mypage/service/MyPageGroomerServiceTest.java
@@ -168,31 +168,28 @@ class MyPageGroomerServiceTest {
     void testSaveGroomerProfileDetails_success() {
         // Given
         Long userId = 1L;
-        GroomerProfileDetailsRequestDto requestDto = createMockRequestDto();
+        GroomerProfileDetailsRequestDto requestDto = createMockDetailRequestDto();
         GroomerProfile mockProfile = createMockGroomerProfile();
         when(groomerProfileRepository.findByUserIdWithDistrict(userId)).thenReturn(Optional.of(mockProfile));
-        when(districtRepository.findAllById(requestDto.getServicesDistrictIds())).thenReturn(createMockDistricts());
 
         // When
         myPageGroomerService.saveGroomerProfileDetails(requestDto, userId);
 
         // Then
         verify(groomerProfileRepository).findByUserIdWithDistrict(userId);
-        verify(districtRepository).findAllById(requestDto.getServicesDistrictIds());
     }
 
     @Test
-    @DisplayName("미용사 프로필 상세 저장 실패 테스트 - 유효하지 않은 지역 ID")
+    @DisplayName("미용사 프로필 상세 저장 실패 테스트 - 프로필 없음")
     void testSaveGroomerProfileDetails_invalidDistrictIds() {
-        // Given
+        /// Given
         Long userId = 1L;
-        GroomerProfileDetailsRequestDto requestDto = createMockRequestDto();
-        when(groomerProfileRepository.findByUserIdWithDistrict(userId)).thenReturn(Optional.of(createMockGroomerProfile()));
-        when(districtRepository.findAllById(requestDto.getServicesDistrictIds())).thenReturn(List.of()); // Empty list
+        when(groomerProfileRepository.findByUserIdWithDistrict(userId)).thenReturn(Optional.empty());
 
         // When & Then
-        assertThrows(IllegalArgumentException.class,
-                () -> myPageGroomerService.saveGroomerProfileDetails(requestDto, userId));
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> myPageGroomerService.getGroomerProfilePage(userId));
+        assertEquals("해당 미용사를 찾을 수 없습니다.", exception.getMessage());
     }
 
     @Test
@@ -297,12 +294,27 @@ class MyPageGroomerServiceTest {
                 .build();
     }
 
-    private GroomerProfileDetailsRequestDto createMockRequestDto() {
-        return GroomerProfileDetailsRequestDto.builder()
+    private GroomerProfileRequestDto createMockRequestDto() {
+        return GroomerProfileRequestDto.builder()
+                .name("미용사")
+                .phone("phone")
+                .contactHours("10-18")
                 .serviceType(ServiceType.SHOP)
-                .imageKey("test_image.png")
                 .servicesDistrictIds(List.of(1L, 2L))
-                .certifications(List.of("Certification1", "Certification2"))
+                .servicesOfferedId(List.of(1L, 2L))
+                .build();
+    }
+
+    private GroomerProfileDetailsRequestDto createMockDetailRequestDto() {
+        return GroomerProfileDetailsRequestDto.builder()
+                .imageKey("image")
+                .businessNumber("number")
+                .address("address")
+                .experience("experience")
+                .description("description")
+                .startMessage("startMessage")
+                .faq("faq")
+                .certifications(List.of("자격증1", "자격증1"))
                 .build();
     }
 
@@ -319,7 +331,7 @@ class MyPageGroomerServiceTest {
     }
 
     private List<DistrictResponseDto> createMockDistrictResponse() {
-        return List.of(new DistrictResponseDto("District1", "city1"), new DistrictResponseDto("District2", "city2"));
+        return List.of(new DistrictResponseDto(1L, "District1", "city1"), new DistrictResponseDto(2L, "District2", "city2"));
     }
 
     private List<String> createMockServiceResponse() {


### PR DESCRIPTION
## 🔍 연관된 이슈

> #34 

## 🔀 작업 내용

> 지역 id 및 미용사 프로필 등록 필수, 선택 필드 변경

- 지역 줄때 districtID 값도 포함해서 주기
   - 마이페이지 메인 조회(유저)
   - 마이페이지 메인 조회(미용사)
   - 미용사 프로필 상세 조회(공개)
   - 사용자 정보 조회

- 프로필 등록 1(필수) 할 때, 방문 형태와 서비스 지역을 추가 

### 📸 스크린샷 or 영상(선택)

> 스크린샷이나 영상이 필요하다면 첨부해주세요.

## 🧐 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
