### PR TITLE
Feat: 콘테스트 게시글 올라올 때 구독자들에게 알림 기능 구현

### DIFF
--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestPostService.java
@@ -26,8 +26,8 @@ public class ContestPostService {
     private final ContestPostRepository contestPostRepository;
     private final GroomerProfileRepository groomerProfileRepository;
     private final UserRepository userRepository;
-
     private final ContestPostLikeService contestPostLikeService;
+    private final ContestTopicNotificationService contestTopicNotificationService;
 
     @Transactional(readOnly = true)
     public Page<PostInfoDto> getContestPosts(Long contestId, Long userId, Pageable pageable) {
@@ -64,6 +64,8 @@ public class ContestPostService {
                 .build();
 
         contestPostRepository.save(joinPost);
+
+        contestTopicNotificationService.sendContestJoinNotification();
     }
 
     @Transactional

--- a/src/main/java/com/dangdangsalon/domain/contest/service/ContestTopicNotificationService.java
+++ b/src/main/java/com/dangdangsalon/domain/contest/service/ContestTopicNotificationService.java
@@ -1,0 +1,30 @@
+package com.dangdangsalon.domain.contest.service;
+
+import com.dangdangsalon.domain.notification.service.NotificationTopicService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ContestTopicNotificationService {
+
+    private final NotificationTopicService notificationTopicService;
+
+    /**
+     * 새로운 게시글 올라오면 구독자들에게 알림 전송
+     */
+    public void sendContestJoinNotification() {
+        String topic = "contest";
+        String title = "새로운 게시글이 올라왔어요!!";
+        String body = "귀여운 강아지 사진이 올라왔어요!! 빠르게 확인해보세요";
+
+        try {
+            notificationTopicService.sendNotificationToTopic(topic, title, body);
+            log.info("'{}' 주제에 알림 전송 완료.", topic);
+        } catch (RuntimeException e) {
+            log.error("'{}' 주제에 알림 전송 실패: {}", topic, e.getMessage(), e);
+        }
+    }
+}

--- a/src/test/java/com/dangdangsalon/domain/contest/service/ContestPostServiceTest.java
+++ b/src/test/java/com/dangdangsalon/domain/contest/service/ContestPostServiceTest.java
@@ -54,6 +54,9 @@ class ContestPostServiceTest {
     @Mock
     private ContestPostLikeService contestPostLikeService;
 
+    @Mock
+    private ContestTopicNotificationService contestTopicNotificationService;
+
     @InjectMocks
     private ContestPostService contestPostService;
 


### PR DESCRIPTION
## 🔍 연관된 이슈

> #44 

## 🔀 작업 내용

> 콘테스트 게시글 올라올 때 구독자들에게 알림 기능 구현)

### 📸 스크린샷 or 영상(선택)

> ![캡처](https://github.com/user-attachments/assets/d17d4726-5bee-4576-977b-6939a5c64820)

## 🧐 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
