### PR TITLE
Chore: 유저 쿠폰 조회 시 NOT_USED 만 가져오게 수정

### DIFF
--- a/src/main/java/com/dangdangsalon/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/dangdangsalon/domain/coupon/service/CouponService.java
@@ -4,6 +4,7 @@ import com.dangdangsalon.domain.coupon.dto.CouponInfoResponseDto;
 import com.dangdangsalon.domain.coupon.dto.CouponMainResponseDto;
 import com.dangdangsalon.domain.coupon.dto.CouponUserResponseDto;
 import com.dangdangsalon.domain.coupon.entity.CouponEvent;
+import com.dangdangsalon.domain.coupon.entity.CouponStatus;
 import com.dangdangsalon.domain.coupon.repository.CouponEventRepository;
 import com.dangdangsalon.domain.user.entity.User;
 import com.dangdangsalon.domain.user.repository.UserRepository;
@@ -41,6 +42,7 @@ public class CouponService {
                 new IllegalArgumentException("유저 아이디를 찾을 수 없습니다. userId : " + userId));
 
         return user.getCoupons().stream()
+                .filter(coupon -> coupon.getStatus() == CouponStatus.NOT_USED) // NOT_USED 상태만 필터링
                 .map(CouponUserResponseDto::create)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## 🔍 연관된 이슈

> #49 

## 🔀 작업 내용

> 유저 쿠폰 조회 시 NOT_USED 만 가져오게 수정

### 📸 스크린샷 or 영상(선택)

> 스크린샷이나 영상이 필요하다면 첨부해주세요.

## 🧐 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
