### PR TITLE
Refactor: ai 강아지 종별 닮은 연예인 추가

### DIFF
--- a/src/main/java/com/dangdangsalon/chatgpt/dto/DogCelebrityMapping.java
+++ b/src/main/java/com/dangdangsalon/chatgpt/dto/DogCelebrityMapping.java
@@ -1,0 +1,69 @@
+package com.dangdangsalon.chatgpt.dto;
+
+public enum DogCelebrityMapping {
+
+    GOLDEN_RETRIEVER("골든 리트리버", "박해진", "https://img.hankyung.com/photo/201601/03.9412505.1.jpg"),
+    CHIHUAHUA("치와와", "김국진", "https://cdn.hankyung.com/photo/202405/03.36635111.1.jpg"),
+    JINDO("진돗개", "서인국", "https://entertainimg.kbsmedia.co.kr/cms/uploads/CONTENTS_20220922155600_54249760516b76bf6d3f816cc872281f.jpg"),
+    CHOW_CHOW("차우차우", "고창석", "https://image.news1.kr/system/photos/2016/5/31/1956615/article.jpg"),
+    BULLDOG("불독", "김구라", "https://img.hankyung.com/photo/202004/AKR20200402161700005_01_i.jpg"),
+    BULL_TERRIER("불테리어", "박명수", "https://m.segye.com/content/image/2024/04/03/20240403506251.png"),
+    SHEPHERD("셰퍼드", "이연복", "https://img6.yna.co.kr/etc/inner/KR/2019/10/29/AKR20191029084100005_01_i_P2.jpg"),
+    SHIH_TZU("시츄", "채수빈", "https://spnimage.edaily.co.kr/images/Photo/files/NP/S/2019/01/PS19011100033.jpg"),
+    POODLE("푸들", "푸들", "https://search.pstatic.net/common/?src=http%3A%2F%2Fimgnews.naver.net%2Fimage%2F609%2F2023%2F12%2F15%2F202312151957421510_1_20231215195804576.jpg&type=a340"),
+    HUSKY("허스키", "이상윤", "https://newsimg.sedaily.com/2019/12/29/1VS9GSK58M_1.jpg"),
+    CORGI("웰시코기", "박보영", "https://i.namu.wiki/i/JkML_XrsJw3fSPzxItjfvxNWtF8XkGA8qs3pm7i-n0c7VRjZlC32xt1Vblx2MmOX3io8syX6aoKkaBAUUBLosA.webp"),
+    DALMATIAN("달마시안", "한지민", "https://pimg.mk.co.kr/news/cms/202411/08/news-p.v1.20241108.693ff74fdbcc4010aada161b6ef59915_P1.jpg"),
+    MALTESE("말티즈", "수지", "https://image.kmib.co.kr/online_image/2022/0629/2022062916360153343_1656488164_0017227708.jpg"),
+    PUG("퍼그", "정형돈", "https://cdn.autotribune.co.kr/news/photo/202405/17638_79108_2333.png"),
+    POMERANIAN("포메라니안", "태연", "https://www.madtimes.org/news/photo/202302/16670_38219_1911.jpg");
+
+    private final String dogType;
+    private final String celebrity;
+    private final String imageUrl;
+
+    DogCelebrityMapping(String dogType, String celebrity, String imageUrl) {
+        this.dogType = dogType;
+        this.celebrity = celebrity;
+        this.imageUrl = imageUrl;
+    }
+
+    public String getDogType() {
+        return dogType;
+    }
+
+    public String getCelebrity() {
+        return celebrity;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public static DogCelebrityInfo matchCelebrity(String analysisResult) {
+        for (DogCelebrityMapping mapping : values()) {
+            if (analysisResult.contains(mapping.getDogType())) {
+                return new DogCelebrityInfo(mapping.getCelebrity(), mapping.getImageUrl());
+            }
+        }
+        return new DogCelebrityInfo("매칭된 연예인이 없습니다.", null);
+    }
+
+    public static class DogCelebrityInfo {
+        private final String celebrity;
+        private final String imageUrl;
+
+        public DogCelebrityInfo(String celebrity, String imageUrl) {
+            this.celebrity = celebrity;
+            this.imageUrl = imageUrl;
+        }
+
+        public String getCelebrity() {
+            return celebrity;
+        }
+
+        public String getImageUrl() {
+            return imageUrl;
+        }
+    }
+}

--- a/src/main/java/com/dangdangsalon/chatgpt/dto/GenerateImageAnalysisResponseDto.java
+++ b/src/main/java/com/dangdangsalon/chatgpt/dto/GenerateImageAnalysisResponseDto.java
@@ -12,4 +12,6 @@ import lombok.NoArgsConstructor;
 public class GenerateImageAnalysisResponseDto {
     private String imageUrl;
     private String translatedAnalysis;
+    private String matchingCelebrity;
+    private String celebrityImageUrl;
 }

--- a/src/main/java/com/dangdangsalon/chatgpt/service/ChatGptService.java
+++ b/src/main/java/com/dangdangsalon/chatgpt/service/ChatGptService.java
@@ -47,16 +47,22 @@ public class ChatGptService {
         String translatedAnalysisResult = translateEngToKo(analysisResult);
         log.info("Translated image analysis result: {}", translatedAnalysisResult);
 
-        // 4. 최종 프롬프트 완성 (사용자 입력 그대로 사용)
+        // 4. 연예인 매칭
+        DogCelebrityMapping.DogCelebrityInfo matchingCelebrityInfo = matchCelebrityByExpression(translatedAnalysisResult);
+        log.info("Matching celebrity: {}, Image URL: {}", matchingCelebrityInfo.getCelebrity(), matchingCelebrityInfo.getImageUrl());
+
+        // 5. 최종 프롬프트 완성 (사용자 입력 그대로 사용)
         String detailedPrompt = createFinalPrompt(userPrompt, translatedAnalysisResult);
         log.info("Detailed prompt: {}", detailedPrompt);
 
-        // 5. 이미지 생성
+        // 6. 이미지 생성
         String generatedImageUrl = createImageFromDescription(detailedPrompt);
 
         return GenerateImageAnalysisResponseDto.builder()
                 .imageUrl(generatedImageUrl)
                 .translatedAnalysis(translatedAnalysisResult)
+                .matchingCelebrity(matchingCelebrityInfo.getCelebrity())
+                .celebrityImageUrl(matchingCelebrityInfo.getImageUrl())
                 .build();
     }
 
@@ -66,7 +72,7 @@ public class ChatGptService {
 
     private String createFinalPrompt(String userPrompt, String analysisResult) {
         return String.format(
-                "사진에는 %s이/가 있습니다. 사진 속 강아지를 %s 강아지로 만들어주세요",
+                "사진에는 %s이/가 있습니다. 사진 속 강아지를 %s 미용 스타일로 만들어주세요",
                 analysisResult,
                 userPrompt
         );
@@ -138,5 +144,9 @@ public class ChatGptService {
             return choice.getMessage().getContent().trim();
         }
         throw new RuntimeException("Failed to analyze image with OpenAI.");
+    }
+
+    private DogCelebrityMapping.DogCelebrityInfo matchCelebrityByExpression(String analysisResult) {
+        return DogCelebrityMapping.matchCelebrity(analysisResult);
     }
 }

--- a/src/test/java/com/dangdangsalon/chatgpt/api/ChatGptApiTest.java
+++ b/src/test/java/com/dangdangsalon/chatgpt/api/ChatGptApiTest.java
@@ -43,7 +43,7 @@ class ChatGptApiTest {
     @DisplayName("이미지 생성 요청 테스트")
     @WithMockUser(username = "testUser", roles = {"USER"})
     void generateImageTest() throws Exception {
-        GenerateImageAnalysisResponseDto mockResponse = new GenerateImageAnalysisResponseDto("generated-image-url","강아지는 행복해보여요");
+        GenerateImageAnalysisResponseDto mockResponse = new GenerateImageAnalysisResponseDto("generated-image-url","강아지는 행복해보여요","카리나","imageUrl");
         when(chatGptService.generateDogStyleImage(anyString(), any())).thenReturn(mockResponse);
 
         MockMultipartFile mockFile = new MockMultipartFile(


### PR DESCRIPTION
## 🔍 연관된 이슈

> #80

## 🔀 작업 내용

> ai 강아지 종별 닮은 연예인 추가

### 📸 스크린샷 or 영상(선택)

> 
![2차수정](https://github.com/user-attachments/assets/69ac7c09-a016-474b-9046-22747cf737a3)

## 🧐 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
