### PR TITLE
Refactor: 결제 승인 취소 재시도 클래스 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 	implementation 'com.google.firebase:firebase-admin:9.4.1'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework:spring-aspects'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dangdangsalon/DangdangSalonServerApplication.java
+++ b/src/main/java/com/dangdangsalon/DangdangSalonServerApplication.java
@@ -5,9 +5,11 @@ import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableRetry
 public class DangdangSalonServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/dangdangsalon/domain/payment/service/PaymentApproveRetryService.java
+++ b/src/main/java/com/dangdangsalon/domain/payment/service/PaymentApproveRetryService.java
@@ -1,0 +1,88 @@
+package com.dangdangsalon.domain.payment.service;
+
+import com.dangdangsalon.domain.payment.dto.PaymentApproveRequestDto;
+import com.dangdangsalon.domain.payment.dto.PaymentApproveResponseDto;
+import com.dangdangsalon.domain.payment.entity.Payment;
+import com.dangdangsalon.domain.payment.entity.PaymentStatus;
+import com.dangdangsalon.domain.payment.repository.PaymentRepository;
+import com.dangdangsalon.domain.orders.entity.Orders;
+import com.dangdangsalon.domain.orders.repository.OrdersRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentApproveRetryService {
+
+    private final WebClient webClient;
+    private final OrdersRepository ordersRepository;
+    private final PaymentRepository paymentRepository;
+
+    @Value("${toss.api.key}")
+    private String tossApiKey;
+
+    @Retryable(
+            retryFor = {WebClientResponseException.class },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000)
+    )
+    public PaymentApproveResponseDto sendApprovalRequestToToss(PaymentApproveRequestDto paymentApproveRequestDto, String url, String idempotencyKey) {
+        String authorizationHeader = "Basic " + Base64.getEncoder().encodeToString((tossApiKey + ":").getBytes());
+        try {
+            return webClient.post()
+                    .uri(url)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                    .header("Idempotency-Key", idempotencyKey)
+                    .bodyValue(Map.of(
+                            "paymentKey", paymentApproveRequestDto.getPaymentKey(),
+                            "orderId", paymentApproveRequestDto.getOrderId(),
+                            "amount", paymentApproveRequestDto.getAmount()
+                    ))
+                    .retrieve()
+                    .bodyToMono(PaymentApproveResponseDto.class)
+                    .block();
+        } catch (WebClientResponseException ex) {
+            log.error("Toss 결제 검증 API 호출 실패: {}", ex.getResponseBodyAsString());
+            throw ex;
+        }
+    }
+
+    @Recover
+    public PaymentApproveResponseDto recover(WebClientResponseException ex, PaymentApproveRequestDto requestDto) {
+        log.error("결제 승인 재시도 실패: 요청 ID={}, 오류={}", requestDto.getOrderId(), ex.getMessage());
+
+        Orders order = ordersRepository.findByTossOrderId(requestDto.getOrderId())
+                .orElseThrow(() -> new IllegalArgumentException("주문 정보를 찾을 수 없습니다: " + requestDto.getOrderId()));
+
+        Payment rejectedPayment = Payment.builder()
+                .paymentKey(requestDto.getPaymentKey())
+                .totalAmount(0)
+                .paymentStatus(PaymentStatus.REJECTED)
+                .requestedAt(LocalDateTime.now())
+                .paymentMethod("UNKNOWN")
+                .orders(order)
+                .coupon(null)
+                .build();
+
+        paymentRepository.save(rejectedPayment);
+
+        return PaymentApproveResponseDto.builder()
+                .status(rejectedPayment.getPaymentStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/payment/service/PaymentApproveService.java
+++ b/src/main/java/com/dangdangsalon/domain/payment/service/PaymentApproveService.java
@@ -20,19 +20,8 @@ import com.dangdangsalon.domain.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Recover;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
-
-import java.time.LocalDateTime;
-import java.util.Base64;
-import java.util.Map;
 
 @Slf4j
 @Service
@@ -44,10 +33,7 @@ class PaymentApproveService {
     private final EstimateRequestRepository estimateRequestRepository;
     private final PaymentNotificationService paymentNotificationService;
     private final CouponRepository couponRepository;
-    private final WebClient webClient;
-
-    @Value("${toss.api.key}")
-    private String tossApiKey;
+    private final PaymentApproveRetryService retryService;
 
     @Value("${toss.api.approve-url}")
     private String tossApproveUrl;
@@ -59,11 +45,8 @@ class PaymentApproveService {
         Orders order = findOrderByTossOrderId(paymentApproveRequestDto.getOrderId());
         validateOrderAmount(order, paymentApproveRequestDto.getAmount());
 
-        PaymentApproveResponseDto paymentResponse = sendApprovalRequestToToss(
-                paymentApproveRequestDto,
-                tossApproveUrl,
-                idempotencyKey
-        );
+        PaymentApproveResponseDto paymentResponse = retryService.sendApprovalRequestToToss(
+                paymentApproveRequestDto, tossApproveUrl, idempotencyKey);
 
         Long couponId = paymentApproveRequestDto.getCouponId();
         Coupon coupon = null;
@@ -81,53 +64,6 @@ class PaymentApproveService {
         paymentNotificationService.sendNotificationToUser(order);
 
         return paymentResponse;
-    }
-
-    @Retryable(
-            retryFor = { WebClientResponseException.class },
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 2000)
-    )
-    public PaymentApproveResponseDto sendApprovalRequestToToss(PaymentApproveRequestDto paymentApproveRequestDto, String url, String idempotencyKey) {
-        String authorizationHeader = "Basic " + Base64.getEncoder().encodeToString((tossApiKey + ":").getBytes());
-
-        try {
-            return webClient.post()
-                    .uri(url)
-                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
-                    .header("Idempotency-Key", idempotencyKey)
-                    .bodyValue(Map.of(
-                            "paymentKey", paymentApproveRequestDto.getPaymentKey(),
-                            "orderId", paymentApproveRequestDto.getOrderId(),
-                            "amount", paymentApproveRequestDto.getAmount()
-                    ))
-                    .retrieve()
-                    .bodyToMono(PaymentApproveResponseDto.class)
-                    .block();
-        } catch (WebClientResponseException ex) {
-            log.error("Toss 결제 검증 API 호출 실패: {}", ex.getResponseBodyAsString());
-            throw new RuntimeException("결제 승인 중 오류가 발생했습니다.");
-        }
-    }
-
-    @Recover
-    public void recover(WebClientResponseException ex, PaymentApproveRequestDto requestDto) {
-        log.error("결제 승인 재시도 실패: 요청 ID={}, 오류={}", requestDto.getOrderId(), ex.getMessage());
-
-        Orders order = findOrderByTossOrderId(requestDto.getOrderId());
-
-        Payment rejectedPayment = Payment.builder()
-                .paymentKey(requestDto.getPaymentKey())
-                .totalAmount(0)
-                .paymentStatus(PaymentStatus.REJECTED)
-                .requestedAt(LocalDateTime.now())
-                .paymentMethod("UNKNOWN")
-                .orders(order)
-                .coupon(null)
-                .build();
-
-        paymentRepository.save(rejectedPayment);
     }
 
     private void validatePaymentAmount(long amount) {

--- a/src/main/java/com/dangdangsalon/domain/payment/service/PaymentCancelRetryService.java
+++ b/src/main/java/com/dangdangsalon/domain/payment/service/PaymentCancelRetryService.java
@@ -1,0 +1,73 @@
+package com.dangdangsalon.domain.payment.service;
+
+import com.dangdangsalon.domain.payment.dto.PaymentCancelRequestDto;
+import com.dangdangsalon.domain.payment.dto.PaymentCancelResponseDto;
+import com.dangdangsalon.domain.payment.entity.Payment;
+import com.dangdangsalon.domain.payment.entity.PaymentStatus;
+import com.dangdangsalon.domain.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.Base64;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentCancelRetryService {
+
+    private final WebClient webClient;
+    private final PaymentRepository paymentRepository;
+
+    @Value("${toss.api.key}")
+    private String tossApiKey;
+
+    @Retryable(
+            retryFor = { WebClientResponseException.class },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000)
+    )
+    public PaymentCancelResponseDto sendCancelRequestToToss(PaymentCancelRequestDto paymentCancelRequestDto, String url, String idempotencyKey) {
+
+        String authorizationHeader = "Basic " + Base64.getEncoder().encodeToString((tossApiKey + ":").getBytes());
+        try {
+            return webClient.post()
+                    .uri(url)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                    .header("Idempotency-Key", idempotencyKey)
+                    .bodyValue(Map.of(
+                            "cancelReason", paymentCancelRequestDto.getCancelReason()
+                    ))
+                    .retrieve()
+                    .bodyToMono(PaymentCancelResponseDto.class)
+                    .block();
+        } catch (WebClientResponseException ex) {
+            log.error("Toss 결제 취소 API 호출 실패: {}", ex.getResponseBodyAsString());
+            throw ex;
+        }
+    }
+
+    @Recover
+    public PaymentCancelResponseDto recover(WebClientResponseException ex, PaymentCancelRequestDto requestDto) {
+        log.error("결제 취소 재시도 실패: 요청 ID={}, 오류={}", requestDto.getPaymentKey(), ex.getMessage());
+
+        Payment payment = paymentRepository.findByPaymentKey(requestDto.getPaymentKey())
+                .orElseThrow(() -> new IllegalArgumentException("결제 정보를 찾을 수 없습니다."));
+
+        payment.updatePaymentStatus(PaymentStatus.REJECTED);
+
+        return PaymentCancelResponseDto.builder()
+                .status(payment.getPaymentStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/com/dangdangsalon/domain/payment/service/PaymentCancelService.java
+++ b/src/main/java/com/dangdangsalon/domain/payment/service/PaymentCancelService.java
@@ -20,18 +20,8 @@ import com.dangdangsalon.domain.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Recover;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
-
-import java.util.Base64;
-import java.util.Map;
 
 @Slf4j
 @Service
@@ -42,10 +32,7 @@ class PaymentCancelService {
     private final EstimateRequestRepository estimateRequestRepository;
     private final CouponRepository couponRepository;
     private final OrdersRepository ordersRepository;
-    private final WebClient webClient;
-
-    @Value("${toss.api.key}")
-    private String tossApiKey;
+    private final PaymentCancelRetryService paymentCancelRetryService;
 
     @Value("${toss.api.cancel-url}")
     private String tossCancelUrl;
@@ -55,11 +42,8 @@ class PaymentCancelService {
         Payment payment = findPaymentByPaymentKey(paymentCancelRequestDto.getPaymentKey());
 
         String cancelUrl = tossCancelUrl.replace("{paymentKey}", paymentCancelRequestDto.getPaymentKey());
-        PaymentCancelResponseDto paymentCancelResponseDto = sendCancelRequestToToss(
-                paymentCancelRequestDto,
-                cancelUrl,
-                idempotencyKey
-        );
+
+        PaymentCancelResponseDto paymentCancelResponseDto = paymentCancelRetryService.sendCancelRequestToToss(paymentCancelRequestDto, cancelUrl, idempotencyKey);
 
         Long couponId = paymentCancelRequestDto.getCouponId();
 
@@ -77,42 +61,6 @@ class PaymentCancelService {
         updatePaymentAndRelatedEntities(payment);
 
         return buildPaymentCancelResponseDto(paymentCancelResponseDto);
-    }
-
-    @Retryable(
-            retryFor = { WebClientResponseException.class },
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 2000)
-    )
-    public PaymentCancelResponseDto sendCancelRequestToToss(PaymentCancelRequestDto paymentCancelRequestDto, String url, String idempotencyKey) {
-
-        String authorizationHeader = "Basic " + Base64.getEncoder().encodeToString((tossApiKey + ":").getBytes());
-        try {
-            return webClient.post()
-                    .uri(url)
-                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
-                    .header("Idempotency-Key", idempotencyKey)
-                    .bodyValue(Map.of(
-                            "cancelReason", paymentCancelRequestDto.getCancelReason()
-                    ))
-                    .retrieve()
-                    .bodyToMono(PaymentCancelResponseDto.class)
-                    .block();
-        } catch (WebClientResponseException ex) {
-            log.error("Toss 결제 취소 API 호출 실패: {}", ex.getResponseBodyAsString());
-            throw new RuntimeException("결제 취소 중 오류가 발생했습니다.");
-        }
-    }
-
-    @Recover
-    public void recover(WebClientResponseException ex, PaymentCancelRequestDto requestDto) {
-        log.error("결제 취소 재시도 실패: 요청 ID={}, 오류={}", requestDto.getPaymentKey(), ex.getMessage());
-
-        Payment payment = paymentRepository.findByPaymentKey(requestDto.getPaymentKey())
-                .orElseThrow(() -> new IllegalArgumentException("결제 정보를 찾을 수 없습니다."));
-
-        payment.updatePaymentStatus(PaymentStatus.REJECTED);
     }
 
     private Payment findPaymentByPaymentKey(String paymentKey) {

--- a/src/test/java/com/dangdangsalon/domain/payment/service/PaymentApproveRetryServiceTest.java
+++ b/src/test/java/com/dangdangsalon/domain/payment/service/PaymentApproveRetryServiceTest.java
@@ -1,0 +1,129 @@
+package com.dangdangsalon.domain.payment.service;
+
+import com.dangdangsalon.domain.payment.dto.PaymentApproveRequestDto;
+import com.dangdangsalon.domain.payment.dto.PaymentApproveResponseDto;
+import com.dangdangsalon.domain.payment.entity.Payment;
+import com.dangdangsalon.domain.payment.entity.PaymentStatus;
+import com.dangdangsalon.domain.payment.repository.PaymentRepository;
+import com.dangdangsalon.domain.orders.entity.Orders;
+import com.dangdangsalon.domain.orders.repository.OrdersRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentApproveRetryServiceTest {
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private WebClient.RequestBodySpec requestBodySpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec<?> requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    @Mock
+    private OrdersRepository ordersRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @InjectMocks
+    private PaymentApproveRetryService paymentApproveRetryService;
+
+    private PaymentApproveRequestDto requestDto;
+    private Orders mockOrder;
+
+    private static final String TEST_APPROVE_URL = "https://api.tosspayments.com/v1/payments/PAYMENT_KEY_123/approve";
+
+    @BeforeEach
+    void setUp() {
+        requestDto = PaymentApproveRequestDto.builder()
+                .paymentKey("PAYMENT_KEY_123")
+                .orderId("ORDER_ID_123")
+                .amount(50000)
+                .build();
+
+        mockOrder = Orders.builder()
+                .tossOrderId("ORDER_ID_123")
+                .build();
+    }
+
+    @Test
+    @DisplayName("결제 승인 API 호출 성공")
+    void sendApprovalRequestToToss_Success() {
+        // Given
+        PaymentApproveResponseDto responseDto = PaymentApproveResponseDto.builder()
+                .paymentKey("PAYMENT_KEY_123")
+                .status("DONE")
+                .build();
+
+        // WebClient Mock 설정
+        given(webClient.post()).willReturn(requestBodyUriSpec);
+        given(requestBodyUriSpec.uri(anyString())).willReturn(requestBodySpec);
+        given(requestBodySpec.header(anyString(), anyString())).willReturn(requestBodySpec);
+        given(requestBodySpec.bodyValue(any())).willAnswer(invocation -> requestHeadersSpec);
+        given(requestHeadersSpec.retrieve()).willReturn(responseSpec);
+
+        // 응답 모킹
+        given(responseSpec.bodyToMono(PaymentApproveResponseDto.class))
+                .willReturn(Mono.just(responseDto));
+
+        // When
+        PaymentApproveResponseDto result = paymentApproveRetryService.sendApprovalRequestToToss(requestDto, TEST_APPROVE_URL, "IDEMPOTENCY_KEY_123");
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo("DONE");
+        assertThat(result.getPaymentKey()).isEqualTo("PAYMENT_KEY_123");
+    }
+
+    @Test
+    @DisplayName("결제 승인 API 재시도 실패 후 복구 로직 검증")
+    void sendApprovalRequestToToss_Failure_And_Recovery() {
+        // Given
+        WebClientResponseException exception = WebClientResponseException.create(500, "Server Error", null, null, null);
+
+        // 주문 Repository 설정
+        given(ordersRepository.findByTossOrderId(anyString())).willReturn(Optional.of(mockOrder));
+
+        Payment[] capturedPayment = new Payment[1];
+        doAnswer(invocation -> {
+            capturedPayment[0] = invocation.getArgument(0);
+            return null;
+        }).when(paymentRepository).save(any(Payment.class));
+
+        // When
+        PaymentApproveResponseDto result = paymentApproveRetryService.recover(exception, requestDto);
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(PaymentStatus.REJECTED.name());
+
+        // 저장된 결제 정보 검증
+        verify(paymentRepository, times(1)).save(any(Payment.class));
+        assertThat(capturedPayment[0]).isNotNull();
+        assertThat(capturedPayment[0].getPaymentStatus()).isEqualTo(PaymentStatus.REJECTED);
+        assertThat(capturedPayment[0].getPaymentKey()).isEqualTo("PAYMENT_KEY_123");
+    }
+}

--- a/src/test/java/com/dangdangsalon/domain/payment/service/PaymentCancelRetryServiceTest.java
+++ b/src/test/java/com/dangdangsalon/domain/payment/service/PaymentCancelRetryServiceTest.java
@@ -1,0 +1,115 @@
+package com.dangdangsalon.domain.payment.service;
+
+import com.dangdangsalon.domain.payment.dto.PaymentCancelRequestDto;
+import com.dangdangsalon.domain.payment.dto.PaymentCancelResponseDto;
+import com.dangdangsalon.domain.payment.entity.Payment;
+import com.dangdangsalon.domain.payment.entity.PaymentStatus;
+import com.dangdangsalon.domain.payment.repository.PaymentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentCancelRetryServiceTest {
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private WebClient.RequestBodySpec requestBodySpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec<?> requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @InjectMocks
+    private PaymentCancelRetryService paymentCancelRetryService;
+
+    private PaymentCancelRequestDto requestDto;
+    private Payment mockPayment;
+
+    private static final String TEST_CANCEL_URL = "https://api.tosspayments.com/v1/payments/PAYMENT_KEY_123/cancel";
+
+    @BeforeEach
+    void setUp() {
+        requestDto = PaymentCancelRequestDto.builder()
+                .paymentKey("PAYMENT_KEY_123")
+                .cancelReason("Test Cancel")
+                .build();
+
+        mockPayment = Payment.builder()
+                .paymentKey("PAYMENT_KEY_123")
+                .paymentStatus(PaymentStatus.ACCEPTED)
+                .build();
+    }
+
+    @Test
+    @DisplayName("결제 취소 API 호출 성공")
+    void sendCancelRequestToToss_Success() {
+        // Given
+        PaymentCancelResponseDto responseDto = PaymentCancelResponseDto.builder()
+                .paymentKey("PAYMENT_KEY_123")
+                .status("CANCELED")
+                .build();
+
+        // WebClient Mock 설정
+        given(webClient.post()).willReturn(requestBodyUriSpec);
+        given(requestBodyUriSpec.uri(anyString())).willReturn(requestBodySpec);
+        given(requestBodySpec.header(anyString(), anyString())).willReturn(requestBodySpec);
+        given(requestBodySpec.bodyValue(any())).willAnswer(invocation -> requestHeadersSpec);
+        given(requestHeadersSpec.retrieve()).willReturn(responseSpec);
+
+        // Use Mono.just() to mock the response
+        given(responseSpec.bodyToMono(PaymentCancelResponseDto.class))
+                .willReturn(Mono.just(responseDto));
+
+        // When
+        PaymentCancelResponseDto result = paymentCancelRetryService.sendCancelRequestToToss(requestDto, TEST_CANCEL_URL, "IDEMPOTENCY_KEY_123");
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo("CANCELED");
+        assertThat(result.getPaymentKey()).isEqualTo("PAYMENT_KEY_123");
+    }
+
+    @Test
+    @DisplayName("결제 취소 API 재시도 실패 후 복구 로직 검증")
+    void sendCancelRequestToToss_Failure_And_Recovery() {
+        // Given
+        WebClientResponseException exception = WebClientResponseException.create(500, "Server Error", null, null, null);
+
+        // 결제 Repository 설정
+        given(paymentRepository.findByPaymentKey(anyString())).willReturn(Optional.of(mockPayment));
+
+        // When
+        PaymentCancelResponseDto result = paymentCancelRetryService.recover(exception, requestDto);
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(PaymentStatus.REJECTED.name());
+
+        // 결제 정보 조회 메서드 호출 확인
+        verify(paymentRepository, times(1)).findByPaymentKey("PAYMENT_KEY_123");
+    }
+}


### PR DESCRIPTION
## 🔍 연관된 이슈

> #37 

## 🔀 작업 내용

> 결제 승인 취소 재시도 클래스 분리
> 네트워크 오류 시 3회 재시도 후 실패시 결제 상태 REJECTED

### 📸 스크린샷 or 영상(선택)

> 스크린샷이나 영상이 필요하다면 첨부해주세요.

## 🧐 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
